### PR TITLE
feat: JyogiAuth::User モジュールを追加

### DIFF
--- a/app/models/jyogi_auth/user.rb
+++ b/app/models/jyogi_auth/user.rb
@@ -22,8 +22,11 @@ module JyogiAuth
     # @param cache [Boolean] キャッシュを使用するか（デフォルト: true）
     # @return [Array<JyogiAuth::User>]
     def self.all(access_token:, cache: true)
+      raise ArgumentError, "access_token cannot be nil" if access_token.nil?
+
       if cache
-        Rails.cache.fetch("jyogi_auth_users", expires_in: 5.minutes) do
+        cache_key = cache_key_for_token(access_token)
+        Rails.cache.fetch(cache_key, expires_in: 5.minutes) do
           fetch_all_from_api(access_token)
         end
       else
@@ -40,6 +43,16 @@ module JyogiAuth
       users_data.map { |user_attrs| new(user_attrs) }
     end
     private_class_method :fetch_all_from_api
+
+    # access_tokenに基づいてキャッシュキーを生成
+    # トークンのハッシュを使用して、異なるトークン間でキャッシュが共有されないようにする
+    # @param access_token [String] 認証トークン
+    # @return [String] キャッシュキー
+    def self.cache_key_for_token(access_token)
+      token_hash = Digest::SHA256.hexdigest(access_token)[0, 16]
+      "jyogi_auth_users:#{token_hash}"
+    end
+    private_class_method :cache_key_for_token
 
     # JyogiAuth APIから特定のユーザーを取得
     # @param id [String] JyogiAuthのユーザーID
@@ -87,8 +100,12 @@ module JyogiAuth
     end
 
     # キャッシュの手動クリア
-    def self.clear_cache
-      Rails.cache.delete("jyogi_auth_users")
+    # @param access_token [String] 認証トークン(特定のトークンのキャッシュのみをクリア)
+    def self.clear_cache(access_token:)
+      raise ArgumentError, "access_token cannot be nil" if access_token.nil?
+
+      cache_key = cache_key_for_token(access_token)
+      Rails.cache.delete(cache_key)
     end
 
     private

--- a/app/models/jyogi_auth/user.rb
+++ b/app/models/jyogi_auth/user.rb
@@ -1,0 +1,103 @@
+# frozen_string_literal: true
+
+module JyogiAuth
+  class User
+    attr_reader :id, :discord_id, :username, :display_name, :avatar_url,
+                :guild_roles, :guild_nickname, :created_at, :updated_at
+
+    def initialize(attributes)
+      @id = attributes["id"] || attributes[:id]
+      @discord_id = attributes["discord_id"] || attributes[:discord_id]
+      @username = attributes["username"] || attributes[:username]
+      @display_name = attributes["display_name"] || attributes[:display_name]
+      @avatar_url = attributes["avatar_url"] || attributes[:avatar_url]
+      @guild_roles = attributes["guild_roles"] || attributes[:guild_roles] || {}
+      @guild_nickname = attributes["guild_nickname"] || attributes[:guild_nickname]
+      @created_at = parse_time(attributes["created_at"] || attributes[:created_at])
+      @updated_at = parse_time(attributes["updated_at"] || attributes[:updated_at])
+    end
+
+    # JyogiAuth APIから全ユーザーを取得（キャッシュ付き）
+    # @param access_token [String] 認証トークン
+    # @param cache [Boolean] キャッシュを使用するか（デフォルト: true）
+    # @return [Array<JyogiAuth::User>]
+    def self.all(access_token:, cache: true)
+      if cache
+        Rails.cache.fetch("jyogi_auth_users", expires_in: 5.minutes) do
+          fetch_all_from_api(access_token)
+        end
+      else
+        fetch_all_from_api(access_token)
+      end
+    end
+
+    # APIから全ユーザーを取得（内部メソッド）
+    # @param access_token [String] 認証トークン
+    # @return [Array<JyogiAuth::User>]
+    def self.fetch_all_from_api(access_token)
+      response = JyogiAuthClient.fetch_users(access_token: access_token)
+      users_data = response["users"] || response[:users] || []
+      users_data.map { |user_attrs| new(user_attrs) }
+    end
+    private_class_method :fetch_all_from_api
+
+    # JyogiAuth APIから特定のユーザーを取得
+    # @param id [String] JyogiAuthのユーザーID
+    # @param access_token [String] 認証トークン
+    # @return [JyogiAuth::User, nil]
+    # @raise [JyogiAuthClient::AuthenticationError] トークンが無効な場合（再認証が必要）
+    def self.find(id, access_token:)
+      response = JyogiAuthClient.fetch_user_by_id(access_token: access_token, user_id: id)
+      new(response) if response
+    rescue JyogiAuthClient::AuthenticationError
+      # 認証エラーは再認証が必要なため、呼び出し元に伝播させる
+      raise
+    rescue JyogiAuthClient::NetworkError, JyogiAuthClient::ValidationError => e
+      Rails.logger.warn "Failed to fetch JyogiAuth user #{id}: #{e.message}"
+      nil
+    end
+
+    # ローカルDBのUserモデルと対応するか確認
+    # @param local_user [User] ローカルのUserモデル
+    # @return [Boolean]
+    def matches_local_user?(local_user)
+      local_user.jyogi_user_id == @id
+    end
+
+    # 表示名を取得（guild_nickname > display_name > username の優先順位）
+    # @return [String]
+    def display_name_with_fallback
+      guild_nickname.presence || display_name.presence || username
+    end
+
+    # JSON形式に変換
+    # @return [Hash]
+    def as_json(options = {})
+      {
+        id: @id,
+        discord_id: @discord_id,
+        username: @username,
+        display_name: @display_name,
+        avatar_url: @avatar_url,
+        guild_roles: @guild_roles,
+        guild_nickname: @guild_nickname,
+        created_at: @created_at,
+        updated_at: @updated_at
+      }
+    end
+
+    # キャッシュの手動クリア
+    def self.clear_cache
+      Rails.cache.delete("jyogi_auth_users")
+    end
+
+    private
+
+    def parse_time(value)
+      return nil if value.nil?
+      value.is_a?(String) ? Time.parse(value) : value
+    rescue ArgumentError
+      nil
+    end
+  end
+end

--- a/app/models/jyogi_auth/user.rb
+++ b/app/models/jyogi_auth/user.rb
@@ -95,7 +95,7 @@ module JyogiAuth
 
     def parse_time(value)
       return nil if value.nil?
-      value.is_a?(String) ? Time.parse(value) : value
+      value.is_a?(String) ? Time.zone.parse(value) : value
     rescue ArgumentError
       nil
     end

--- a/app/models/jyogi_auth/user.rb
+++ b/app/models/jyogi_auth/user.rb
@@ -35,7 +35,7 @@ module JyogiAuth
     # @param access_token [String] 認証トークン
     # @return [Array<JyogiAuth::User>]
     def self.fetch_all_from_api(access_token)
-      response = JyogiAuthClient.fetch_users(access_token: access_token)
+      response = JyogiAuthClient.fetch_users(access_token: access_token) || {}
       users_data = response["users"] || response[:users] || []
       users_data.map { |user_attrs| new(user_attrs) }
     end

--- a/test/models/jyogi_auth/user_test.rb
+++ b/test/models/jyogi_auth/user_test.rb
@@ -18,6 +18,15 @@ module JyogiAuth
       }
     end
 
+    # キャッシュを有効にしてブロックを実行するヘルパーメソッド
+    def with_caching
+      original_cache = Rails.cache
+      Rails.cache = ActiveSupport::Cache::MemoryStore.new
+      yield
+    ensure
+      Rails.cache = original_cache
+    end
+
     test "initializes with string keys" do
       user = JyogiAuth::User.new(@valid_attributes)
 
@@ -130,10 +139,104 @@ module JyogiAuth
       assert_equal time, user.created_at
     end
 
-    test "clear_cache calls Rails.cache.delete with correct key" do
-        Rails.cache.write("jyogi_auth_users", [ "dummy" ])
-        JyogiAuth::User.clear_cache
-        assert_nil Rails.cache.read("jyogi_auth_users")
+    test "clear_cache deletes cache for specific token" do
+      with_caching do
+        access_token = "test_token_123"
+        cache_key = JyogiAuth::User.send(:cache_key_for_token, access_token)
+
+        Rails.cache.write(cache_key, ["dummy"])
+        JyogiAuth::User.clear_cache(access_token: access_token)
+        assert_nil Rails.cache.read(cache_key)
       end
+    end
+
+    test "clear_cache raises error when access_token is nil" do
+      assert_raises(ArgumentError) do
+        JyogiAuth::User.clear_cache(access_token: nil)
+      end
+    end
+
+    test "clear_cache only deletes cache for specified token" do
+      with_caching do
+        token1 = "token_1"
+        token2 = "token_2"
+        cache_key1 = JyogiAuth::User.send(:cache_key_for_token, token1)
+        cache_key2 = JyogiAuth::User.send(:cache_key_for_token, token2)
+
+        # Write cache for both tokens
+        Rails.cache.write(cache_key1, ["dummy1"])
+        Rails.cache.write(cache_key2, ["dummy2"])
+
+        # Verify both caches exist before clearing
+        assert_equal ["dummy1"], Rails.cache.read(cache_key1), "cache_key1 should contain dummy1"
+        assert_equal ["dummy2"], Rails.cache.read(cache_key2), "cache_key2 should contain dummy2"
+
+        # Clear only token1's cache
+        JyogiAuth::User.clear_cache(access_token: token1)
+
+        # Verify only token1's cache was deleted
+        assert_nil Rails.cache.read(cache_key1), "cache_key1 should be deleted"
+        assert_equal ["dummy2"], Rails.cache.read(cache_key2), "cache_key2 should still exist"
+      end
+    end
+
+    test "User.all generates different cache keys for different tokens" do
+      token1 = "token_1"
+      token2 = "token_2"
+
+      cache_key1 = JyogiAuth::User.send(:cache_key_for_token, token1)
+      cache_key2 = JyogiAuth::User.send(:cache_key_for_token, token2)
+
+      # Different tokens should produce different cache keys
+      refute_equal cache_key1, cache_key2
+      assert_match(/^jyogi_auth_users:[0-9a-f]{16}$/, cache_key1)
+      assert_match(/^jyogi_auth_users:[0-9a-f]{16}$/, cache_key2)
+    end
+
+    test "User.all uses token-specific cache key" do
+      with_caching do
+        token = "test_token_456"
+        expected_cache_key = JyogiAuth::User.send(:cache_key_for_token, token)
+
+        # Pre-populate cache with dummy data
+        dummy_users = [JyogiAuth::User.new({ "id" => "cached_user", "username" => "cached" })]
+        Rails.cache.write(expected_cache_key, dummy_users)
+
+        # Read the cache back to verify it was written correctly
+        cached_data = Rails.cache.read(expected_cache_key)
+        assert_not_nil cached_data, "Cache should contain data"
+        assert_equal 1, cached_data.length
+        assert_equal "cached_user", cached_data.first.id
+        assert_equal "cached", cached_data.first.username
+      end
+    end
+
+    test "User.all raises error when access_token is nil" do
+      assert_raises(ArgumentError) do
+        JyogiAuth::User.all(access_token: nil)
+      end
+    end
+
+    test "cache_key_for_token generates consistent hash for same token" do
+      token = "consistent_token"
+
+      key1 = JyogiAuth::User.send(:cache_key_for_token, token)
+      key2 = JyogiAuth::User.send(:cache_key_for_token, token)
+
+      # Same token should always generate the same cache key
+      assert_equal key1, key2
+    end
+
+    test "cache_key_for_token uses SHA256 hash" do
+      token = "test_token_for_hash"
+      cache_key = JyogiAuth::User.send(:cache_key_for_token, token)
+
+      # Verify the format includes a 16-character hex hash
+      assert_match(/^jyogi_auth_users:[0-9a-f]{16}$/, cache_key)
+
+      # Verify it's actually the first 16 chars of SHA256
+      expected_hash = Digest::SHA256.hexdigest(token)[0, 16]
+      assert_equal "jyogi_auth_users:#{expected_hash}", cache_key
+    end
   end
 end

--- a/test/models/jyogi_auth/user_test.rb
+++ b/test/models/jyogi_auth/user_test.rb
@@ -1,0 +1,140 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module JyogiAuth
+  class UserTest < ActiveSupport::TestCase
+    def setup
+      @valid_attributes = {
+        "id" => "user-123",
+        "discord_id" => "123456789",
+        "username" => "testuser",
+        "display_name" => "Test User",
+        "avatar_url" => "https://example.com/avatar.png",
+        "guild_roles" => { "role1" => "value1" },
+        "guild_nickname" => "Test Nickname",
+        "created_at" => "2024-01-01T00:00:00Z",
+        "updated_at" => "2024-01-02T00:00:00Z"
+      }
+    end
+
+    test "initializes with string keys" do
+      user = JyogiAuth::User.new(@valid_attributes)
+
+      assert_equal "user-123", user.id
+      assert_equal "123456789", user.discord_id
+      assert_equal "testuser", user.username
+      assert_equal "Test User", user.display_name
+      assert_equal "https://example.com/avatar.png", user.avatar_url
+      assert_equal({ "role1" => "value1" }, user.guild_roles)
+      assert_equal "Test Nickname", user.guild_nickname
+      assert_instance_of Time, user.created_at
+      assert_instance_of Time, user.updated_at
+    end
+
+    test "initializes with symbol keys" do
+      attributes = {
+        id: "user-456",
+        discord_id: "987654321",
+        username: "symboluser",
+        display_name: "Symbol User"
+      }
+
+      user = JyogiAuth::User.new(attributes)
+
+      assert_equal "user-456", user.id
+      assert_equal "987654321", user.discord_id
+      assert_equal "symboluser", user.username
+      assert_equal "Symbol User", user.display_name
+    end
+
+    test "guild_roles defaults to empty hash" do
+      user = JyogiAuth::User.new({ "id" => "user-123" })
+
+      assert_equal({}, user.guild_roles)
+    end
+
+    test "display_name_with_fallback returns guild_nickname when present" do
+      user = JyogiAuth::User.new(@valid_attributes)
+
+      assert_equal "Test Nickname", user.display_name_with_fallback
+    end
+
+    test "display_name_with_fallback returns display_name when guild_nickname is nil" do
+      attributes = @valid_attributes.merge("guild_nickname" => nil)
+      user = JyogiAuth::User.new(attributes)
+
+      assert_equal "Test User", user.display_name_with_fallback
+    end
+
+    test "display_name_with_fallback returns username when both guild_nickname and display_name are nil" do
+      attributes = @valid_attributes.merge("guild_nickname" => nil, "display_name" => nil)
+      user = JyogiAuth::User.new(attributes)
+
+      assert_equal "testuser", user.display_name_with_fallback
+    end
+
+    test "display_name_with_fallback handles blank values" do
+      attributes = @valid_attributes.merge("guild_nickname" => "", "display_name" => "")
+      user = JyogiAuth::User.new(attributes)
+
+      assert_equal "testuser", user.display_name_with_fallback
+    end
+
+    test "matches_local_user? returns true when jyogi_user_id matches" do
+      user = JyogiAuth::User.new(@valid_attributes)
+      local_user = ::User.new(jyogi_user_id: "user-123")
+
+      assert user.matches_local_user?(local_user)
+    end
+
+    test "matches_local_user? returns false when jyogi_user_id does not match" do
+      user = JyogiAuth::User.new(@valid_attributes)
+      local_user = ::User.new(jyogi_user_id: "different-id")
+
+      refute user.matches_local_user?(local_user)
+    end
+
+    test "as_json returns hash with all attributes" do
+      user = JyogiAuth::User.new(@valid_attributes)
+      json = user.as_json
+
+      assert_equal "user-123", json[:id]
+      assert_equal "123456789", json[:discord_id]
+      assert_equal "testuser", json[:username]
+      assert_equal "Test User", json[:display_name]
+      assert_equal "https://example.com/avatar.png", json[:avatar_url]
+      assert_equal({ "role1" => "value1" }, json[:guild_roles])
+      assert_equal "Test Nickname", json[:guild_nickname]
+    end
+
+    test "parse_time handles nil value" do
+      attributes = @valid_attributes.merge("created_at" => nil)
+      user = JyogiAuth::User.new(attributes)
+
+      assert_nil user.created_at
+    end
+
+    test "parse_time handles invalid time string" do
+      attributes = @valid_attributes.merge("created_at" => "invalid-time")
+      user = JyogiAuth::User.new(attributes)
+
+      assert_nil user.created_at
+    end
+
+    test "parse_time handles Time object" do
+      time = Time.current
+      attributes = @valid_attributes.merge("created_at" => time)
+      user = JyogiAuth::User.new(attributes)
+
+      assert_equal time, user.created_at
+    end
+
+    test "clear_cache calls Rails.cache.delete with correct key" do
+      # clear_cache がエラーなく実行されることを確認
+      assert_nothing_raised do
+        JyogiAuth::User.clear_cache
+      end
+    end
+  end
+end

--- a/test/models/jyogi_auth/user_test.rb
+++ b/test/models/jyogi_auth/user_test.rb
@@ -28,8 +28,8 @@ module JyogiAuth
       assert_equal "https://example.com/avatar.png", user.avatar_url
       assert_equal({ "role1" => "value1" }, user.guild_roles)
       assert_equal "Test Nickname", user.guild_nickname
-      assert_instance_of Time, user.created_at
-      assert_instance_of Time, user.updated_at
+      assert_instance_of ActiveSupport::TimeWithZone, user.created_at
+      assert_instance_of ActiveSupport::TimeWithZone, user.updated_at
     end
 
     test "initializes with symbol keys" do
@@ -131,10 +131,9 @@ module JyogiAuth
     end
 
     test "clear_cache calls Rails.cache.delete with correct key" do
-      # clear_cache がエラーなく実行されることを確認
-      assert_nothing_raised do
+        Rails.cache.write("jyogi_auth_users", ["dummy"])
         JyogiAuth::User.clear_cache
+        assert_nil Rails.cache.read("jyogi_auth_users")
       end
-    end
   end
 end

--- a/test/models/jyogi_auth/user_test.rb
+++ b/test/models/jyogi_auth/user_test.rb
@@ -131,7 +131,7 @@ module JyogiAuth
     end
 
     test "clear_cache calls Rails.cache.delete with correct key" do
-        Rails.cache.write("jyogi_auth_users", ["dummy"])
+        Rails.cache.write("jyogi_auth_users", [ "dummy" ])
         JyogiAuth::User.clear_cache
         assert_nil Rails.cache.read("jyogi_auth_users")
       end


### PR DESCRIPTION
JyogiAuth APIからユーザー情報を取得するためのモジュールを追加
- JyogiAuth::User クラスの実装
- ユーザー一覧取得、個別取得機能
- テストを追加

Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * JyogiAuth のユーザー表現を追加：ID、Discord ID、ユーザー名、表示名、アバター、ギルドロール等を扱えるように
  * API 同期と取得結果の短期キャッシュ（デフォルト5分）およびキャッシュクリア機能を追加
  * ローカルユーザー照合と表示名フォールバック（ニックネーム→表示名→ユーザー名）を実装
  * JSON 出力に対応

* **テスト**
  * 上記機能を網羅する単体テストを追加

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->