### PR TITLE
Renderへの修正

### DIFF
--- a/db/migrate/20260117093000_create_roles_and_add_role_to_users.rb
+++ b/db/migrate/20260117093000_create_roles_and_add_role_to_users.rb
@@ -7,12 +7,26 @@ class CreateRolesAndAddRoleToUsers < ActiveRecord::Migration[8.1]
 
         t.timestamps
       end
+    end
+
+    # rolesテーブルのユニークインデックスを確認・追加
+    if table_exists?(:roles) && !index_exists?(:roles, :name, unique: true)
       add_index :roles, :name, unique: true
     end
 
-    # role_idカラムが存在しない場合のみ追加
+    # role_idカラムが存在しない場合のみ追加（外部キーとインデックス含む）
     unless column_exists?(:users, :role_id)
       add_reference :users, :role, foreign_key: { to_table: :roles }
+    else
+      # カラムは存在するが外部キーが無い場合
+      unless foreign_key_exists?(:users, :roles)
+        add_foreign_key :users, :roles, column: :role_id
+      end
+
+      # カラムは存在するがインデックスが無い場合
+      unless index_exists?(:users, :role_id)
+        add_index :users, :role_id
+      end
     end
   end
 end


### PR DESCRIPTION
マイグレーションエラーが発生しています。マイグレーションファイルを確認します。 

[](file:///c%3A/Users/User/Documents/GitHub/JyogiRooms/db/migrate/20260117093000_create_roles_and_add_role_to_users.rb) の読み取り

問題は、production環境で既にusersテーブルにデータがある状態で`add_reference`を実行すると、外部キー制約でエラーが発生する可能性があります。また、トランザクションが失敗した状態になっているようです。

マイグレーションを安全に実行できるように修正します： 

Using "ファイル内の文字列の置換"


修正しました。マイグレーションを冪等性のあるものに変更：

**対応内容：**
- `unless table_exists?(:roles)` - rolesテーブルが既に存在する場合はスキップ
- `unless column_exists?(:users, :role_id)` - role_idカラムが既に存在する場合はスキップ

これにより、部分的に実行済みの状態でも安全に再実行できます。

デプロイ前に、本番環境でマイグレーションをリセットする必要があるかもしれません。Renderのダッシュボードから以下のコマンドを実行してください：

```bash
rails db:migrate:status
rails db:rollback STEP=1
rails db:migrate
```

または、完全にリセットする場合：
```bash
rails db:migrate VERSION=20260110025525
rails db:migrate
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * データベースマイグレーションの堅牢性を向上させました。既存のテーブルやカラムが存在する場合の冗長な処理を避けるため、条件付き実行ロジックを改善しました。

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->