### PR TITLE
Discord botのCloud Runデプロイ設定を追加

### DIFF
--- a/.github/workflows/deploy-discord-bot.yml
+++ b/.github/workflows/deploy-discord-bot.yml
@@ -1,0 +1,58 @@
+name: Deploy Discord Bot to Cloud Run
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - 'discord-bot/**'
+
+env:
+  PROJECT_ID: jyogirooms
+  REGION: asia-northeast1
+  IMAGE: asia-northeast1-docker.pkg.dev/jyogirooms/jyogi-rooms/discord-bot
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: projects/877085301688/locations/global/workloadIdentityPools/github-pool/providers/github-provider
+          service_account: 877085301688-compute@developer.gserviceaccount.com
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Configure Docker for Artifact Registry
+        run: gcloud auth configure-docker ${{ env.REGION }}-docker.pkg.dev --quiet
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v6
+        with:
+          context: ./discord-bot
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.IMAGE }}:${{ github.sha }}
+            ${{ env.IMAGE }}:latest
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Deploy to Cloud Run
+        uses: google-github-actions/deploy-cloudrun@v2
+        with:
+          service: jyogi-discord-bot
+          region: ${{ env.REGION }}
+          image: ${{ env.IMAGE }}:${{ github.sha }}
+          project_id: ${{ env.PROJECT_ID }}

--- a/discord-bot/Dockerfile
+++ b/discord-bot/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:22-slim AS build
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci
+COPY tsconfig.json ./
+COPY src/ src/
+RUN npm run build
+
+FROM node:22-slim
+WORKDIR /app
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev
+COPY --from=build /app/dist/ dist/
+
+USER node
+EXPOSE 3000
+CMD ["node", "dist/index.js"]


### PR DESCRIPTION
Dockerfileとdevelop pushでdiscord-bot/配下の変更時に自動デプロイするGitHub Actionsワークフローを追加

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Discord bot の自動デプロイメント パイプラインを設定しました。develop ブランチへのプッシュ時に、Docker コンテナイメージが自動ビルドされ、Cloud Run にデプロイされるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->