### PR TITLE
237/rita/entry exit management phase2

### DIFF
--- a/app/controllers/api/nfc_registrations_controller.rb
+++ b/app/controllers/api/nfc_registrations_controller.rb
@@ -46,7 +46,12 @@ module Api
         return render json: { error: "このカードは既に登録されています" }, status: :unprocessable_entity
       end
 
-      NfcCard.create!(user: current_user, card_uid: @registration.card_uid)
+      NfcCard.create!(
+        user: current_user,
+        card_uid: @registration.card_uid,
+        student_id: @registration.student_id,
+        student_name: @registration.student_name
+      )
       @registration.destroy!
 
       render json: { message: "NFCカードを登録しました" }, status: :ok
@@ -71,6 +76,8 @@ module Api
         id: registration.id,
         user_id: registration.user_id,
         card_uid: registration.card_uid,
+        student_id: registration.student_id,
+        student_name: registration.student_name,
         expires_at: registration.expires_at.iso8601,
         expired: registration.expired?,
         pending: registration.pending?,

--- a/app/controllers/api/nfc_registrations_controller.rb
+++ b/app/controllers/api/nfc_registrations_controller.rb
@@ -53,8 +53,10 @@ module Api
           student_id: @registration.student_id,
           student_name: @registration.student_name
         )
-      rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid
+      rescue ActiveRecord::RecordNotUnique
         return render json: { error: "このカードは既に登録されています" }, status: :unprocessable_entity
+      rescue ActiveRecord::RecordInvalid => e
+        return render json: { error: e.record.errors.full_messages.join(", ") }, status: :unprocessable_entity
       end
 
       @registration.destroy!

--- a/app/controllers/api/nfc_registrations_controller.rb
+++ b/app/controllers/api/nfc_registrations_controller.rb
@@ -46,14 +46,18 @@ module Api
         return render json: { error: "このカードは既に登録されています" }, status: :unprocessable_entity
       end
 
-      NfcCard.create!(
-        user: current_user,
-        card_uid: @registration.card_uid,
-        student_id: @registration.student_id,
-        student_name: @registration.student_name
-      )
-      @registration.destroy!
+      begin
+        NfcCard.create!(
+          user: current_user,
+          card_uid: @registration.card_uid,
+          student_id: @registration.student_id,
+          student_name: @registration.student_name
+        )
+      rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid
+        return render json: { error: "このカードは既に登録されています" }, status: :unprocessable_entity
+      end
 
+      @registration.destroy!
       render json: { message: "NFCカードを登録しました" }, status: :ok
     end
 

--- a/app/controllers/api/nfc_registrations_controller.rb
+++ b/app/controllers/api/nfc_registrations_controller.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+module Api
+  # NFC登録API（Webアプリから利用）
+  class NfcRegistrationsController < BaseController
+    before_action :authenticate_user!
+    before_action :set_registration, only: %i[show confirm destroy]
+
+    # POST /api/nfc_registrations
+    def create
+      if current_user.nfc_card.present?
+        return render json: { error: "既にカードが登録されています" }, status: :unprocessable_entity
+      end
+
+      # 期限切れのリクエストをクリーンアップ
+      NfcRegistrationRequest.expired.delete_all
+
+      registration = current_user.nfc_registration_requests.build(
+        expires_at: 1.minute.from_now
+      )
+
+      if registration.save
+        render json: registration_json(registration), status: :created
+      else
+        render json: { errors: registration.errors.full_messages }, status: :unprocessable_entity
+      end
+    end
+
+    # GET /api/nfc_registrations/:id
+    def show
+      render json: registration_json(@registration)
+    end
+
+    # PATCH /api/nfc_registrations/:id/confirm
+    def confirm
+      if @registration.expired?
+        return render json: { error: "登録リクエストの有効期限が切れています" }, status: :unprocessable_entity
+      end
+
+      unless @registration.completed?
+        return render json: { error: "カードがまだ読み取られていません" }, status: :unprocessable_entity
+      end
+
+      # 既に登録済みのカードでないか確認
+      if NfcCard.exists?(card_uid: @registration.card_uid)
+        return render json: { error: "このカードは既に登録されています" }, status: :unprocessable_entity
+      end
+
+      NfcCard.create!(user: current_user, card_uid: @registration.card_uid)
+      @registration.destroy!
+
+      render json: { message: "NFCカードを登録しました" }, status: :ok
+    end
+
+    # DELETE /api/nfc_registrations/:id
+    def destroy
+      @registration.destroy!
+      head :no_content
+    end
+
+    private
+
+    def set_registration
+      @registration = current_user.nfc_registration_requests.find(params[:id])
+    rescue ActiveRecord::RecordNotFound
+      render json: { error: "登録リクエストが見つかりません" }, status: :not_found
+    end
+
+    def registration_json(registration)
+      {
+        id: registration.id,
+        user_id: registration.user_id,
+        card_uid: registration.card_uid,
+        expires_at: registration.expires_at.iso8601,
+        expired: registration.expired?,
+        pending: registration.pending?,
+        completed: registration.completed?
+      }
+    end
+  end
+end

--- a/app/controllers/api/rooms/touches_controller.rb
+++ b/app/controllers/api/rooms/touches_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module Api
+  module Rooms
+    # NFC Raspi専用: カードタッチによる入退室・カード登録
+    class TouchesController < BaseController
+      skip_before_action :authenticate_user!
+      before_action :authenticate_api_key!
+
+      # POST /api/rooms/:room_id/touch
+      def create
+        room = Room.find(params[:room_id])
+        result = NfcTouchService.process(room: room, card_uid: params[:card_uid])
+
+        render json: result, status: :ok
+      rescue ActiveRecord::RecordNotFound
+        render json: { error: "部室が見つかりません" }, status: :not_found
+      rescue NfcTouchService::TouchError => e
+        render json: { error: e.message }, status: :unprocessable_entity
+      rescue RoomEntryService::EntryError => e
+        render json: { error: e.message }, status: :unprocessable_entity
+      end
+    end
+  end
+end

--- a/app/controllers/api/rooms/touches_controller.rb
+++ b/app/controllers/api/rooms/touches_controller.rb
@@ -10,7 +10,8 @@ module Api
       # POST /api/rooms/:room_id/touch
       def create
         room = Room.find(params[:room_id])
-        result = NfcTouchService.process(room: room, card_uid: params[:card_uid])
+        card_data = params.permit(:student_id, :student_name).to_h.symbolize_keys
+        result = NfcTouchService.process(room: room, card_uid: params[:card_uid], card_data: card_data)
 
         render json: result, status: :ok
       rescue ActiveRecord::RecordNotFound

--- a/app/controllers/nfc_cards_controller.rb
+++ b/app/controllers/nfc_cards_controller.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class NfcCardsController < ApplicationController
+  before_action :authenticate_user!
+
+  # GET /nfc_cards
+  def index
+    @nfc_card = current_user.nfc_card
+  end
+
+  # DELETE /nfc_cards/:id
+  def destroy
+    card = NfcCard.find(params[:id])
+
+    if card.user_id != current_user.id
+      redirect_to nfc_cards_path, alert: "権限がありません"
+      return
+    end
+
+    card.destroy!
+    redirect_to nfc_cards_path, notice: "NFCカードを削除しました"
+  rescue ActiveRecord::RecordNotFound
+    redirect_to nfc_cards_path, alert: "カードが見つかりません"
+  end
+end

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -3,7 +3,8 @@ module NavigationHelper
     items = [
       { path: root_path, icon: :home, label: "ホーム", active: current_page?(root_path) },
       { path: reservations_path, icon: :calendar, label: "部室予約", active: current_page?(reservations_path) },
-      { path: keys_path, icon: :key, label: "鍵管理", active: current_page?(keys_path) }
+      { path: keys_path, icon: :key, label: "鍵管理", active: current_page?(keys_path) },
+      { path: nfc_cards_path, icon: :nfc, label: "NFCカード", active: current_page?(nfc_cards_path) }
     ]
 
     # 管理者のみ管理画面へのリンクを表示
@@ -24,6 +25,8 @@ module NavigationHelper
                "M15.75 5.25a3 3 0 0 1 3 3m3 0a6 6 0 0 1-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1 1 21.75 8.25Z"
     when :shield
                "M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z"
+    when :nfc
+               "M10.5 1.5H8.25A2.25 2.25 0 0 0 6 3.75v16.5a2.25 2.25 0 0 0 2.25 2.25h7.5A2.25 2.25 0 0 0 18 20.25V3.75a2.25 2.25 0 0 0-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3m-3 18.75h3"
     end
 
     content = tag.path(d: path_d, stroke_linecap: "round", stroke_linejoin: "round")

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -3,8 +3,7 @@ module NavigationHelper
     items = [
       { path: root_path, icon: :home, label: "ホーム", active: current_page?(root_path) },
       { path: reservations_path, icon: :calendar, label: "部室予約", active: current_page?(reservations_path) },
-      { path: keys_path, icon: :key, label: "鍵管理", active: current_page?(keys_path) },
-      { path: nfc_cards_path, icon: :nfc, label: "NFCカード", active: current_page?(nfc_cards_path) }
+      { path: keys_path, icon: :key, label: "鍵管理", active: current_page?(keys_path) }
     ]
 
     # 管理者のみ管理画面へのリンクを表示
@@ -25,8 +24,7 @@ module NavigationHelper
                "M15.75 5.25a3 3 0 0 1 3 3m3 0a6 6 0 0 1-7.029 5.912c-.563-.097-1.159.026-1.563.43L10.5 17.25H8.25v2.25H6v2.25H2.25v-2.818c0-.597.237-1.17.659-1.591l6.499-6.499c.404-.404.527-1 .43-1.563A6 6 0 1 1 21.75 8.25Z"
     when :shield
                "M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z"
-    when :nfc
-               "M10.5 1.5H8.25A2.25 2.25 0 0 0 6 3.75v16.5a2.25 2.25 0 0 0 2.25 2.25h7.5A2.25 2.25 0 0 0 18 20.25V3.75a2.25 2.25 0 0 0-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3m-3 18.75h3"
+
     end
 
     content = tag.path(d: path_d, stroke_linecap: "round", stroke_linejoin: "round")

--- a/app/models/nfc_card.rb
+++ b/app/models/nfc_card.rb
@@ -4,4 +4,5 @@ class NfcCard < ApplicationRecord
   belongs_to :user
 
   validates :card_uid, presence: true, uniqueness: true
+  validates :user_id, uniqueness: { message: "には既にカードが登録されています" }
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,7 +3,7 @@ class User < ApplicationRecord
   has_many :reservations
   has_many :access_tokens, dependent: :destroy
   has_many :keys, dependent: :destroy
-  has_many :nfc_cards, dependent: :destroy
+  has_one :nfc_card, dependent: :destroy
   has_many :room_visits, dependent: :restrict_with_error
   has_many :nfc_registration_requests, dependent: :destroy
 

--- a/app/services/nfc_touch_service.rb
+++ b/app/services/nfc_touch_service.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+# NFC Raspiからのタッチ処理を統括するサービス
+# card_uidから自動で入室/退室/カード登録を判定
+class NfcTouchService
+  class TouchError < StandardError; end
+
+  # @param room [Room]
+  # @param card_uid [String]
+  # @return [Hash] { action: String, user: User, ... }
+  def self.process(room:, card_uid:)
+    nfc_card = NfcCard.find_by(card_uid: card_uid)
+
+    if nfc_card
+      handle_registered_card(room: room, nfc_card: nfc_card)
+    else
+      handle_unregistered_card(card_uid: card_uid)
+    end
+  end
+
+  # 登録済みカード: 入退室トグル
+  def self.handle_registered_card(room:, nfc_card:)
+    user = nfc_card.user
+    result = RoomEntryService.toggle(room: room, user: user, source: "nfc")
+
+    {
+      action: result[:action],
+      user: { id: user.id, display_name: user.display_name },
+      room: { id: room.id, name: room.name },
+      timestamp: Time.current.iso8601
+    }
+  end
+
+  # 未登録カード: 登録待ちがあればcard_uidを保存
+  def self.handle_unregistered_card(card_uid:)
+    # 期限切れのリクエストをクリーンアップ
+    NfcRegistrationRequest.expired.delete_all
+
+    pending_request = NfcRegistrationRequest.pending.first
+    raise TouchError, "未登録のカードです" unless pending_request
+
+    pending_request.update!(card_uid: card_uid)
+
+    {
+      action: "registration",
+      user: { id: pending_request.user_id, display_name: pending_request.user.display_name },
+      card_uid: card_uid,
+      timestamp: Time.current.iso8601
+    }
+  end
+
+  private_class_method :handle_registered_card, :handle_unregistered_card
+end

--- a/app/services/nfc_touch_service.rb
+++ b/app/services/nfc_touch_service.rb
@@ -7,14 +7,15 @@ class NfcTouchService
 
   # @param room [Room]
   # @param card_uid [String]
+  # @param card_data [Hash] { student_id:, student_name: } (optional)
   # @return [Hash] { action: String, user: User, ... }
-  def self.process(room:, card_uid:)
+  def self.process(room:, card_uid:, card_data: {})
     nfc_card = NfcCard.find_by(card_uid: card_uid)
 
     if nfc_card
       handle_registered_card(room: room, nfc_card: nfc_card)
     else
-      handle_unregistered_card(card_uid: card_uid)
+      handle_unregistered_card(card_uid: card_uid, card_data: card_data)
     end
   end
 
@@ -32,14 +33,18 @@ class NfcTouchService
   end
 
   # 未登録カード: 登録待ちがあればcard_uidを保存
-  def self.handle_unregistered_card(card_uid:)
+  def self.handle_unregistered_card(card_uid:, card_data: {})
     # 期限切れのリクエストをクリーンアップ
     NfcRegistrationRequest.expired.delete_all
 
     pending_request = NfcRegistrationRequest.pending.first
     raise TouchError, "未登録のカードです" unless pending_request
 
-    pending_request.update!(card_uid: card_uid)
+    pending_request.update!(
+      card_uid: card_uid,
+      student_id: card_data[:student_id],
+      student_name: card_data[:student_name]
+    )
 
     {
       action: "registration",

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -62,7 +62,12 @@
       <div class="p-4 border-t border-gray-200 relative">
         <div class="group">
           <button type="button" class="w-full flex items-center gap-3 px-2 py-2 rounded-lg hover:bg-gray-100 transition-colors focus:outline-none focus:bg-gray-100">
-            <%= render(UserAvatarComponent.new(user: current_user, size: :medium)) %>
+            <div class="relative">
+              <%= render(UserAvatarComponent.new(user: current_user, size: :medium)) %>
+              <% if current_user && !current_user.nfc_card %>
+                <span class="absolute -top-1 -right-1 w-3.5 h-3.5 bg-red-500 border-2 border-white rounded-full"></span>
+              <% end %>
+            </div>
             <div class="flex flex-col text-left flex-1">
               <span class="text-sm font-bold text-gray-800"><%= current_user ? current_user.display_name : "Guest" %></span>
               <span class="text-xs text-gray-500">@<%= current_user ? current_user.username : "guest" %></span>
@@ -70,7 +75,16 @@
           </button>
           <!-- Dropdown Menu -->
           <div class="absolute bottom-full left-4 right-4 mb-2 bg-white border border-gray-200 rounded-lg shadow-lg opacity-0 invisible group-focus-within:opacity-100 group-focus-within:visible transition-all duration-200">
-            <%= button_to auth_logout_path, method: :delete, class: "w-full flex items-center gap-3 px-4 py-3 text-left text-red-600 hover:bg-red-50 rounded-lg transition-colors", form: { onsubmit: "return confirm('ログアウトしますか？')" } do %>
+            <%= link_to nfc_cards_path, class: "w-full flex items-center gap-3 px-4 py-3 text-gray-700 hover:bg-gray-50 rounded-t-lg transition-colors" do %>
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.5 1.5H8.25A2.25 2.25 0 006 3.75v16.5a2.25 2.25 0 002.25 2.25h7.5A2.25 2.25 0 0018 20.25V3.75a2.25 2.25 0 00-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3m-3 18.75h3"></path>
+              </svg>
+              <span class="text-sm font-medium">NFCカード</span>
+              <% if current_user && !current_user.nfc_card %>
+                <span class="ml-auto text-xs text-red-500 font-medium">未登録</span>
+              <% end %>
+            <% end %>
+            <%= button_to auth_logout_path, method: :delete, class: "w-full flex items-center gap-3 px-4 py-3 text-left text-red-600 hover:bg-red-50 rounded-b-lg transition-colors border-t border-gray-100", form: { onsubmit: "return confirm('ログアウトしますか？')" } do %>
               <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"></path>
               </svg>
@@ -87,8 +101,11 @@
       <!-- Mobile User Menu (checkbox toggle for real mobile support) -->
       <div class="relative">
         <input type="checkbox" id="mobile-menu-toggle" class="peer hidden">
-        <label for="mobile-menu-toggle" class="cursor-pointer">
+        <label for="mobile-menu-toggle" class="cursor-pointer relative">
           <%= render(UserAvatarComponent.new(user: current_user, size: :small)) %>
+          <% if current_user && !current_user.nfc_card %>
+            <span class="absolute -top-1 -right-1 w-3 h-3 bg-red-500 border-2 border-white rounded-full"></span>
+          <% end %>
         </label>
         <!-- Backdrop to close menu -->
         <label for="mobile-menu-toggle" class="fixed inset-0 z-40 hidden peer-checked:block"></label>
@@ -98,7 +115,16 @@
             <p class="text-sm font-bold text-gray-800"><%= current_user ? current_user.display_name : "Guest" %></p>
             <p class="text-xs text-gray-500">@<%= current_user ? current_user.username : "guest" %></p>
           </div>
-          <%= button_to auth_logout_path, method: :delete, class: "w-full flex items-center gap-3 px-4 py-3 text-left text-red-600 hover:bg-red-50 transition-colors", form: { onsubmit: "return confirm('ログアウトしますか？')" } do %>
+          <%= link_to nfc_cards_path, class: "w-full flex items-center gap-3 px-4 py-3 text-gray-700 hover:bg-gray-50 transition-colors" do %>
+            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.5 1.5H8.25A2.25 2.25 0 006 3.75v16.5a2.25 2.25 0 002.25 2.25h7.5A2.25 2.25 0 0018 20.25V3.75a2.25 2.25 0 00-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3m-3 18.75h3"></path>
+            </svg>
+            <span class="text-sm font-medium">NFCカード</span>
+            <% if current_user && !current_user.nfc_card %>
+              <span class="ml-auto text-xs text-red-500 font-medium">未登録</span>
+            <% end %>
+          <% end %>
+          <%= button_to auth_logout_path, method: :delete, class: "w-full flex items-center gap-3 px-4 py-3 text-left text-red-600 hover:bg-red-50 transition-colors border-t border-gray-100", form: { onsubmit: "return confirm('ログアウトしますか？')" } do %>
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"></path>
             </svg>

--- a/app/views/nfc_cards/index.html.erb
+++ b/app/views/nfc_cards/index.html.erb
@@ -217,10 +217,19 @@
               stopTimers();
               cardUidEl.textContent = pollData.card_uid;
               if (pollData.student_name || pollData.student_id) {
-                let html = "";
-                if (pollData.student_name) html += `<p class="text-base font-bold text-gray-800">${pollData.student_name}</p>`;
-                if (pollData.student_id) html += `<p class="text-sm text-gray-600">${pollData.student_id}</p>`;
-                cardInfoEl.innerHTML = html;
+                cardInfoEl.replaceChildren();
+                if (pollData.student_name) {
+                  const nameEl = document.createElement("p");
+                  nameEl.className = "text-base font-bold text-gray-800";
+                  nameEl.textContent = pollData.student_name;
+                  cardInfoEl.appendChild(nameEl);
+                }
+                if (pollData.student_id) {
+                  const idEl = document.createElement("p");
+                  idEl.className = "text-sm text-gray-600";
+                  idEl.textContent = pollData.student_id;
+                  cardInfoEl.appendChild(idEl);
+                }
                 cardInfoEl.classList.remove("hidden");
               }
               showState(confirmEl);

--- a/app/views/nfc_cards/index.html.erb
+++ b/app/views/nfc_cards/index.html.erb
@@ -1,0 +1,228 @@
+<div class="space-y-6 px-4 py-6 md:px-8">
+  <h1 class="text-2xl font-bold text-gray-800">NFCカード管理</h1>
+
+  <!-- Flash Messages -->
+  <% if flash[:notice] %>
+    <div class="bg-green-50 text-green-700 p-4 rounded-lg text-sm">
+      <%= flash[:notice] %>
+    </div>
+  <% end %>
+  <% if flash[:alert] %>
+    <div class="bg-red-50 text-red-700 p-4 rounded-lg text-sm">
+      <%= flash[:alert] %>
+    </div>
+  <% end %>
+
+  <!-- 登録済みカード -->
+  <div class="card p-6">
+    <h2 class="text-lg font-bold text-gray-800 mb-4">登録済みカード</h2>
+
+    <% if @nfc_card %>
+      <div class="flex items-center justify-between bg-gray-50 rounded-lg p-4 border border-gray-200">
+        <div>
+          <p class="text-sm font-medium text-gray-800">カードUID: <%= @nfc_card.card_uid %></p>
+          <p class="text-xs text-gray-500">登録日: <%= @nfc_card.created_at.in_time_zone("Asia/Tokyo").strftime("%Y/%m/%d %H:%M") %></p>
+        </div>
+        <%= button_to "削除", nfc_card_path(@nfc_card), method: :delete,
+            class: "px-3 py-1.5 bg-red-500 text-white text-xs font-medium rounded-md hover:bg-red-600 transition-colors",
+            form: { onsubmit: "return confirm('このカードを削除しますか？')" } %>
+      </div>
+    <% else %>
+      <p class="text-sm text-gray-500">登録済みのカードはありません</p>
+    <% end %>
+  </div>
+
+  <!-- NFC登録セクション -->
+  <% unless @nfc_card %>
+  <div class="card p-6" id="nfc-registration">
+    <h2 class="text-lg font-bold text-gray-800 mb-4">学生証を登録</h2>
+    <p class="text-sm text-gray-600 mb-4">
+      登録を開始すると1分間カードの読み取り待ち状態になります。<br>
+      部室のNFCリーダーに学生証をかざしてください。
+    </p>
+
+    <!-- 登録前 -->
+    <div id="registration-idle">
+      <button type="button" id="start-registration-btn"
+              class="px-4 py-2 bg-primary text-white text-sm font-medium rounded-lg hover:bg-primary-dark transition-colors">
+        カード登録を開始
+      </button>
+    </div>
+
+    <!-- 登録待ち -->
+    <div id="registration-pending" class="hidden">
+      <div class="flex items-center gap-3 mb-4">
+        <div class="animate-spin h-5 w-5 border-2 border-primary border-t-transparent rounded-full"></div>
+        <p class="text-sm font-medium text-gray-700">カードを読み取り中...</p>
+      </div>
+      <p class="text-xs text-gray-500 mb-3">残り時間: <span id="countdown" class="font-mono">60</span>秒</p>
+      <button type="button" id="cancel-registration-btn"
+              class="px-4 py-2 bg-gray-200 text-gray-700 text-sm font-medium rounded-lg hover:bg-gray-300 transition-colors">
+        キャンセル
+      </button>
+    </div>
+
+    <!-- カード確認 -->
+    <div id="registration-confirm" class="hidden">
+      <div class="bg-green-50 border border-green-200 rounded-lg p-4 mb-4">
+        <p class="text-sm font-medium text-green-700">カードを読み取りました</p>
+        <p class="text-sm text-green-600 mt-1">カードUID: <span id="detected-card-uid" class="font-mono"></span></p>
+      </div>
+      <div class="flex gap-3">
+        <button type="button" id="confirm-registration-btn"
+                class="px-4 py-2 bg-primary text-white text-sm font-medium rounded-lg hover:bg-primary-dark transition-colors">
+          このカードを登録する
+        </button>
+        <button type="button" id="reject-registration-btn"
+                class="px-4 py-2 bg-gray-200 text-gray-700 text-sm font-medium rounded-lg hover:bg-gray-300 transition-colors">
+          キャンセル
+        </button>
+      </div>
+    </div>
+
+    <!-- エラー表示 -->
+    <div id="registration-error" class="hidden">
+      <div class="bg-red-50 border border-red-200 rounded-lg p-4 mb-4">
+        <p class="text-sm text-red-700" id="error-message"></p>
+      </div>
+      <button type="button" id="retry-registration-btn"
+              class="px-4 py-2 bg-primary text-white text-sm font-medium rounded-lg hover:bg-primary-dark transition-colors">
+        再試行
+      </button>
+    </div>
+  </div>
+  <% end %>
+</div>
+
+<script>
+  document.addEventListener("DOMContentLoaded", () => {
+    if (!document.getElementById("nfc-registration")) return;
+
+    const csrfToken = document.querySelector('meta[name="csrf-token"]')?.content;
+    const headers = { "Content-Type": "application/json", "X-CSRF-Token": csrfToken };
+
+    const idleEl = document.getElementById("registration-idle");
+    const pendingEl = document.getElementById("registration-pending");
+    const confirmEl = document.getElementById("registration-confirm");
+    const errorEl = document.getElementById("registration-error");
+    const countdownEl = document.getElementById("countdown");
+    const cardUidEl = document.getElementById("detected-card-uid");
+    const errorMessageEl = document.getElementById("error-message");
+
+    let registrationId = null;
+    let pollTimer = null;
+    let countdownTimer = null;
+    let remainingSeconds = 60;
+
+    function showState(state) {
+      [idleEl, pendingEl, confirmEl, errorEl].forEach(el => el.classList.add("hidden"));
+      state.classList.remove("hidden");
+    }
+
+    function stopTimers() {
+      if (pollTimer) { clearInterval(pollTimer); pollTimer = null; }
+      if (countdownTimer) { clearInterval(countdownTimer); countdownTimer = null; }
+    }
+
+    function showError(message) {
+      errorMessageEl.textContent = message;
+      showState(errorEl);
+      stopTimers();
+    }
+
+    // 登録開始
+    document.getElementById("start-registration-btn").addEventListener("click", async () => {
+      try {
+        const res = await fetch("/api/nfc_registrations", { method: "POST", headers });
+        const data = await res.json();
+        if (!res.ok) {
+          showError(data.errors?.join(", ") || data.error || "登録の開始に失敗しました");
+          return;
+        }
+
+        registrationId = data.id;
+        remainingSeconds = 60;
+        countdownEl.textContent = remainingSeconds;
+        showState(pendingEl);
+
+        // カウントダウン
+        countdownTimer = setInterval(() => {
+          remainingSeconds--;
+          countdownEl.textContent = remainingSeconds;
+          if (remainingSeconds <= 0) {
+            showError("タイムアウトしました。再度お試しください。");
+            deleteRegistration();
+          }
+        }, 1000);
+
+        // ポーリング（2秒間隔）
+        pollTimer = setInterval(async () => {
+          try {
+            const pollRes = await fetch(`/api/nfc_registrations/${registrationId}`, { headers: { "Content-Type": "application/json" } });
+            if (!pollRes.ok) return;
+            const pollData = await pollRes.json();
+
+            if (pollData.completed) {
+              stopTimers();
+              cardUidEl.textContent = pollData.card_uid;
+              showState(confirmEl);
+            } else if (pollData.expired) {
+              showError("タイムアウトしました。再度お試しください。");
+            }
+          } catch (e) {
+            // ポーリングエラーは無視（次回リトライ）
+          }
+        }, 2000);
+      } catch (e) {
+        showError("通信エラーが発生しました");
+      }
+    });
+
+    // キャンセル
+    document.getElementById("cancel-registration-btn").addEventListener("click", () => {
+      stopTimers();
+      deleteRegistration();
+      showState(idleEl);
+    });
+
+    // 確定
+    document.getElementById("confirm-registration-btn").addEventListener("click", async () => {
+      try {
+        const res = await fetch(`/api/nfc_registrations/${registrationId}/confirm`, {
+          method: "PATCH", headers
+        });
+        const data = await res.json();
+        if (res.ok) {
+          window.location.reload();
+        } else {
+          showError(data.error || "登録に失敗しました");
+        }
+      } catch (e) {
+        showError("通信エラーが発生しました");
+      }
+    });
+
+    // 確認画面でキャンセル
+    document.getElementById("reject-registration-btn").addEventListener("click", () => {
+      deleteRegistration();
+      showState(idleEl);
+    });
+
+    // 再試行
+    document.getElementById("retry-registration-btn").addEventListener("click", () => {
+      showState(idleEl);
+    });
+
+    async function deleteRegistration() {
+      if (!registrationId) return;
+      try {
+        await fetch(`/api/nfc_registrations/${registrationId}`, {
+          method: "DELETE", headers
+        });
+      } catch (e) {
+        // 削除失敗は無視
+      }
+      registrationId = null;
+    }
+  });
+</script>

--- a/app/views/nfc_cards/index.html.erb
+++ b/app/views/nfc_cards/index.html.erb
@@ -182,12 +182,17 @@
     }
 
     // 登録開始
-    document.getElementById("start-registration-btn").addEventListener("click", async () => {
+    const startBtn = document.getElementById("start-registration-btn");
+    startBtn.addEventListener("click", async () => {
+      if (startBtn.disabled) return;
+      startBtn.disabled = true;
+
       try {
         const res = await fetch("/api/nfc_registrations", { method: "POST", headers });
         const data = await res.json();
         if (!res.ok) {
           showError(data.errors?.join(", ") || data.error || "登録の開始に失敗しました");
+          startBtn.disabled = false;
           return;
         }
 
@@ -216,8 +221,9 @@
             if (pollData.completed) {
               stopTimers();
               cardUidEl.textContent = pollData.card_uid;
+              cardInfoEl.replaceChildren();
+              cardInfoEl.classList.add("hidden");
               if (pollData.student_name || pollData.student_id) {
-                cardInfoEl.replaceChildren();
                 if (pollData.student_name) {
                   const nameEl = document.createElement("p");
                   nameEl.className = "text-base font-bold text-gray-800";
@@ -242,6 +248,8 @@
         }, 2000);
       } catch (e) {
         showError("通信エラーが発生しました");
+      } finally {
+        startBtn.disabled = false;
       }
     });
 

--- a/app/views/nfc_cards/index.html.erb
+++ b/app/views/nfc_cards/index.html.erb
@@ -19,7 +19,15 @@
     <h2 class="text-lg font-bold text-gray-800 mb-4">登録済みカード</h2>
     <div class="flex items-center justify-between bg-gray-50 rounded-lg p-4 border border-gray-200">
       <div>
-        <p class="text-sm font-medium text-gray-800">カードUID: <%= @nfc_card.card_uid %></p>
+        <% if @nfc_card.student_name.present? || @nfc_card.student_id.present? %>
+          <p class="text-sm font-medium text-gray-800">
+            <%= @nfc_card.student_name %>
+            <% if @nfc_card.student_id.present? %>
+              <span class="text-gray-500">(<%= @nfc_card.student_id %>)</span>
+            <% end %>
+          </p>
+        <% end %>
+        <p class="text-xs text-gray-500">カードUID: <%= @nfc_card.card_uid %></p>
         <p class="text-xs text-gray-500">登録日: <%= @nfc_card.created_at.in_time_zone("Asia/Tokyo").strftime("%Y/%m/%d %H:%M") %></p>
       </div>
       <%= button_to "削除", nfc_card_path(@nfc_card), method: :delete,
@@ -63,7 +71,8 @@
     <div id="registration-confirm" class="hidden">
       <div class="bg-green-50 border border-green-200 rounded-lg p-4 mb-4">
         <p class="text-sm font-medium text-green-700">カードを読み取りました</p>
-        <p class="text-sm text-green-600 mt-1">カードUID: <span id="detected-card-uid" class="font-mono"></span></p>
+        <p id="detected-card-info" class="text-sm text-green-600 mt-1 hidden"></p>
+        <p class="text-xs text-green-600 mt-1">カードUID: <span id="detected-card-uid" class="font-mono"></span></p>
       </div>
       <div class="flex gap-3">
         <button type="button" id="confirm-registration-btn"
@@ -132,6 +141,7 @@
     const errorEl = document.getElementById("registration-error");
     const countdownEl = document.getElementById("countdown");
     const cardUidEl = document.getElementById("detected-card-uid");
+    const cardInfoEl = document.getElementById("detected-card-info");
     const errorMessageEl = document.getElementById("error-message");
 
     let registrationId = null;
@@ -190,6 +200,11 @@
             if (pollData.completed) {
               stopTimers();
               cardUidEl.textContent = pollData.card_uid;
+              const infoParts = [pollData.student_name, pollData.student_id].filter(Boolean);
+              if (infoParts.length > 0) {
+                cardInfoEl.textContent = infoParts.join(" / ");
+                cardInfoEl.classList.remove("hidden");
+              }
               showState(confirmEl);
             } else if (pollData.expired) {
               showError("タイムアウトしました。再度お試しください。");

--- a/app/views/nfc_cards/index.html.erb
+++ b/app/views/nfc_cards/index.html.erb
@@ -14,23 +14,20 @@
   <% end %>
 
   <!-- 登録済みカード -->
+  <% if @nfc_card %>
   <div class="card p-6">
     <h2 class="text-lg font-bold text-gray-800 mb-4">登録済みカード</h2>
-
-    <% if @nfc_card %>
-      <div class="flex items-center justify-between bg-gray-50 rounded-lg p-4 border border-gray-200">
-        <div>
-          <p class="text-sm font-medium text-gray-800">カードUID: <%= @nfc_card.card_uid %></p>
-          <p class="text-xs text-gray-500">登録日: <%= @nfc_card.created_at.in_time_zone("Asia/Tokyo").strftime("%Y/%m/%d %H:%M") %></p>
-        </div>
-        <%= button_to "削除", nfc_card_path(@nfc_card), method: :delete,
-            class: "px-3 py-1.5 bg-red-500 text-white text-xs font-medium rounded-md hover:bg-red-600 transition-colors",
-            form: { onsubmit: "return confirm('このカードを削除しますか？')" } %>
+    <div class="flex items-center justify-between bg-gray-50 rounded-lg p-4 border border-gray-200">
+      <div>
+        <p class="text-sm font-medium text-gray-800">カードUID: <%= @nfc_card.card_uid %></p>
+        <p class="text-xs text-gray-500">登録日: <%= @nfc_card.created_at.in_time_zone("Asia/Tokyo").strftime("%Y/%m/%d %H:%M") %></p>
       </div>
-    <% else %>
-      <p class="text-sm text-gray-500">登録済みのカードはありません</p>
-    <% end %>
+      <%= button_to "削除", nfc_card_path(@nfc_card), method: :delete,
+          class: "px-3 py-1.5 bg-red-500 text-white text-xs font-medium rounded-md hover:bg-red-600 transition-colors",
+          form: { onsubmit: "return confirm('このカードを削除しますか？')" } %>
+    </div>
   </div>
+  <% end %>
 
   <!-- NFC登録セクション -->
   <% unless @nfc_card %>
@@ -92,6 +89,34 @@
     </div>
   </div>
   <% end %>
+
+  <!-- 使い方ガイド -->
+  <div class="card p-6">
+    <h2 class="text-lg font-bold text-gray-800 mb-4">使い方</h2>
+    <div class="space-y-4">
+      <div>
+        <h3 class="text-sm font-bold text-gray-700 mb-2">学生証の登録方法</h3>
+        <ol class="text-sm text-gray-600 list-decimal list-inside space-y-1">
+          <li>「カード登録を開始」ボタンを押す</li>
+          <li>1分以内に部室のNFCリーダーに学生証をかざす</li>
+          <li>画面に表示されたカード情報を確認して「登録する」を押す</li>
+        </ol>
+      </div>
+      <div>
+        <h3 class="text-sm font-bold text-gray-700 mb-2">入退室の仕方</h3>
+        <p class="text-sm text-gray-600">
+          登録済みの学生証を部室のNFCリーダーにかざすだけで入退室できます。<br>
+          かざすたびに入室と退室が自動で切り替わります。
+        </p>
+      </div>
+      <div class="bg-blue-50 border border-blue-200 rounded-lg p-3">
+        <p class="text-xs text-blue-700">
+          部室が閉まっている状態でかざすと自動で開室されます。<br>
+          最後の1人が退室すると自動で閉室されます。
+        </p>
+      </div>
+    </div>
+  </div>
 </div>
 
 <script>

--- a/app/views/nfc_cards/index.html.erb
+++ b/app/views/nfc_cards/index.html.erb
@@ -17,21 +17,31 @@
   <% if @nfc_card %>
   <div class="card p-6">
     <h2 class="text-lg font-bold text-gray-800 mb-4">登録済みカード</h2>
-    <div class="flex items-center justify-between bg-gray-50 rounded-lg p-4 border border-gray-200">
-      <div>
-        <% if @nfc_card.student_name.present? || @nfc_card.student_id.present? %>
-          <p class="text-sm font-medium text-gray-800">
-            <%= @nfc_card.student_name %>
-            <% if @nfc_card.student_id.present? %>
-              <span class="text-gray-500">(<%= @nfc_card.student_id %>)</span>
-            <% end %>
-          </p>
-        <% end %>
-        <p class="text-xs text-gray-500">カードUID: <%= @nfc_card.card_uid %></p>
-        <p class="text-xs text-gray-500">登録日: <%= @nfc_card.created_at.in_time_zone("Asia/Tokyo").strftime("%Y/%m/%d %H:%M") %></p>
+    <div class="bg-gray-50 border border-gray-200 rounded-xl p-5">
+      <div class="flex items-start justify-between mb-4">
+        <div class="flex items-center gap-2">
+          <svg class="w-5 h-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.5 1.5H8.25A2.25 2.25 0 006 3.75v16.5a2.25 2.25 0 002.25 2.25h7.5A2.25 2.25 0 0018 20.25V3.75a2.25 2.25 0 00-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3m-3 18.75h3"></path>
+          </svg>
+          <span class="text-xs font-medium text-gray-500">NFC Card</span>
+        </div>
+        <span class="text-xs text-gray-500"><%= @nfc_card.created_at.in_time_zone("Asia/Tokyo").strftime("%Y/%m/%d") %> 登録</span>
       </div>
-      <%= button_to "削除", nfc_card_path(@nfc_card), method: :delete,
-          class: "px-3 py-1.5 bg-red-500 text-white text-xs font-medium rounded-md hover:bg-red-600 transition-colors",
+      <% if @nfc_card.student_name.present? || @nfc_card.student_id.present? %>
+        <div class="mb-3">
+          <% if @nfc_card.student_name.present? %>
+            <p class="text-base font-bold text-gray-800"><%= @nfc_card.student_name %></p>
+          <% end %>
+          <% if @nfc_card.student_id.present? %>
+            <p class="text-sm text-gray-600"><%= @nfc_card.student_id %></p>
+          <% end %>
+        </div>
+      <% end %>
+      <p class="text-xs font-mono text-gray-500 tracking-wider"><%= @nfc_card.card_uid %></p>
+    </div>
+    <div class="mt-3 flex justify-end">
+      <%= button_to "カードを削除", nfc_card_path(@nfc_card), method: :delete,
+          class: "px-3 py-1.5 text-red-500 text-xs font-medium hover:text-red-700 transition-colors",
           form: { onsubmit: "return confirm('このカードを削除しますか？')" } %>
     </div>
   </div>
@@ -69,10 +79,16 @@
 
     <!-- カード確認 -->
     <div id="registration-confirm" class="hidden">
-      <div class="bg-green-50 border border-green-200 rounded-lg p-4 mb-4">
-        <p class="text-sm font-medium text-green-700">カードを読み取りました</p>
-        <p id="detected-card-info" class="text-sm text-green-600 mt-1 hidden"></p>
-        <p class="text-xs text-green-600 mt-1">カードUID: <span id="detected-card-uid" class="font-mono"></span></p>
+      <p class="text-sm font-medium text-green-600 mb-3">カードを読み取りました</p>
+      <div class="bg-gray-50 border border-gray-200 rounded-xl p-5 mb-4">
+        <div class="flex items-center gap-2 mb-3">
+          <svg class="w-5 h-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.5 1.5H8.25A2.25 2.25 0 006 3.75v16.5a2.25 2.25 0 002.25 2.25h7.5A2.25 2.25 0 0018 20.25V3.75a2.25 2.25 0 00-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3m-3 18.75h3"></path>
+          </svg>
+          <span class="text-xs font-medium text-gray-500">NFC Card</span>
+        </div>
+        <div id="detected-card-info" class="mb-3 hidden"></div>
+        <p class="text-xs font-mono text-gray-500 tracking-wider"><span id="detected-card-uid"></span></p>
       </div>
       <div class="flex gap-3">
         <button type="button" id="confirm-registration-btn"
@@ -200,9 +216,11 @@
             if (pollData.completed) {
               stopTimers();
               cardUidEl.textContent = pollData.card_uid;
-              const infoParts = [pollData.student_name, pollData.student_id].filter(Boolean);
-              if (infoParts.length > 0) {
-                cardInfoEl.textContent = infoParts.join(" / ");
+              if (pollData.student_name || pollData.student_id) {
+                let html = "";
+                if (pollData.student_name) html += `<p class="text-base font-bold text-gray-800">${pollData.student_name}</p>`;
+                if (pollData.student_id) html += `<p class="text-sm text-gray-600">${pollData.student_id}</p>`;
+                cardInfoEl.innerHTML = html;
                 cardInfoEl.classList.remove("hidden");
               }
               showState(confirmEl);

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   root "dashboard#index"
   resources :reservations, except: [ :show ]
   resources :keys, only: [ :index ]
+  resources :nfc_cards, only: %i[index destroy]
 
   resources :rooms, only: [] do
     resource :key, only: [] do
@@ -38,6 +39,18 @@ Rails.application.routes.draw do
     # ユーザー情報
     get "users/me", to: "users#me"
     resources :users, only: %i[index show create update destroy]
+
+    # NFC入退室
+    resources :rooms, only: [] do
+      post :touch, to: "rooms/touches#create"
+    end
+
+    # NFC登録
+    resources :nfc_registrations, only: %i[create show destroy] do
+      member do
+        patch :confirm
+      end
+    end
   end
 
   # 管理者画面

--- a/db/migrate/20260326000006_add_unique_index_on_nfc_cards_user_id.rb
+++ b/db/migrate/20260326000006_add_unique_index_on_nfc_cards_user_id.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddUniqueIndexOnNfcCardsUserId < ActiveRecord::Migration[8.1]
+  def change
+    remove_index :nfc_cards, :user_id
+    add_index :nfc_cards, :user_id, unique: true
+  end
+end

--- a/db/migrate/20260326000007_add_card_data_to_nfc_cards.rb
+++ b/db/migrate/20260326000007_add_card_data_to_nfc_cards.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddCardDataToNfcCards < ActiveRecord::Migration[8.1]
+  def change
+    add_column :nfc_cards, :student_id, :string
+    add_column :nfc_cards, :student_name, :string
+  end
+end

--- a/db/migrate/20260326000008_add_card_data_to_nfc_registration_requests.rb
+++ b/db/migrate/20260326000008_add_card_data_to_nfc_registration_requests.rb
@@ -1,0 +1,8 @@
+# frozen_string_literal: true
+
+class AddCardDataToNfcRegistrationRequests < ActiveRecord::Migration[8.1]
+  def change
+    add_column :nfc_registration_requests, :student_id, :string
+    add_column :nfc_registration_requests, :student_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_26_000006) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_26_000008) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -52,6 +52,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_26_000006) do
   create_table "nfc_cards", force: :cascade do |t|
     t.string "card_uid", null: false
     t.datetime "created_at", null: false
+    t.string "student_id"
+    t.string "student_name"
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["card_uid"], name: "index_nfc_cards_on_card_uid", unique: true
@@ -62,6 +64,8 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_26_000006) do
     t.string "card_uid"
     t.datetime "created_at", null: false
     t.datetime "expires_at", null: false
+    t.string "student_id"
+    t.string "student_name"
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["expires_at"], name: "index_nfc_registration_requests_on_expires_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_03_26_000005) do
+ActiveRecord::Schema[8.1].define(version: 2026_03_26_000006) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -55,7 +55,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_03_26_000005) do
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["card_uid"], name: "index_nfc_cards_on_card_uid", unique: true
-    t.index ["user_id"], name: "index_nfc_cards_on_user_id"
+    t.index ["user_id"], name: "index_nfc_cards_on_user_id", unique: true
   end
 
   create_table "nfc_registration_requests", force: :cascade do |t|

--- a/docs/design_nfc_room_entry.md
+++ b/docs/design_nfc_room_entry.md
@@ -39,10 +39,15 @@
 | カラム | 型 | 制約 | 説明 |
 |--------|------|------|------|
 | id | bigint | PK | |
-| user_id | bigint | FK, NOT NULL | 所有ユーザー |
-| card_uid | string | NOT NULL, UNIQUE | 学生証のNFC UID |
+| user_id | bigint | FK, NOT NULL, UNIQUE | 所有ユーザー（1人1枚） |
+| card_uid | string | NOT NULL, UNIQUE | NFCカードのUID |
+| student_id | string | | 学籍番号（任意） |
+| student_name | string | | 氏名（任意） |
 | created_at | datetime | NOT NULL | |
 | updated_at | datetime | NOT NULL | |
+
+- **1ユーザー1枚のみ登録可能**（user_idにユニーク制約）
+- `student_id`・`student_name`は学生証で登録した場合のみ保存される（学生証以外のNFCカードでも登録可能）
 
 ### nfc_registration_requests（NFC登録待ち）
 
@@ -51,6 +56,8 @@
 | id | bigint | PK | |
 | user_id | bigint | FK, NOT NULL | 登録待ちユーザー |
 | card_uid | string | | かざされたカードUID（読み取り後に保存） |
+| student_id | string | | 学籍番号（読み取り後に保存） |
+| student_name | string | | 氏名（読み取り後に保存） |
 | expires_at | datetime | NOT NULL | 有効期限（作成から1分） |
 | created_at | datetime | NOT NULL | |
 | updated_at | datetime | NOT NULL | |
@@ -139,7 +146,11 @@ NFC Raspi専用。カードUIDから自動で入室/退室/カード登録を判
 
 **リクエスト:**
 ```json
-{ "card_uid": "ABC123" }
+{
+  "card_uid": "ABC123",
+  "student_id": "24A001",
+  "student_name": "田中太郎"
+}
 ```
 
 **処理フロー:**

--- a/docs/nfc_raspi_guide.md
+++ b/docs/nfc_raspi_guide.md
@@ -20,13 +20,27 @@ Raspi側の役割は **NFCカードのUIDを読み取り、Rails APIにPOSTす�
 
 ### リクエスト
 
+**学生証以外のNFCカードの場合:**
 ```json
 {
   "card_uid": "04A1B2C3D4E5F6"
 }
 ```
 
-- `card_uid`: NFCカードから読み取ったUID（16進数文字列）
+**学生証の場合:**
+```json
+{
+  "card_uid": "04A1B2C3D4E5F6",
+  "student_id": "24A001",
+  "student_name": "田中太郎"
+}
+```
+
+| パラメータ | 型 | 必須 | 説明 |
+|-----------|------|------|------|
+| `card_uid` | string | 必須 | NFCカードのUID（16進数文字列） |
+| `student_id` | string | 任意 | 学籍番号（学生証から読み取った場合） |
+| `student_name` | string | 任意 | 氏名（学生証から読み取った場合） |
 
 ### レスポンス
 
@@ -89,14 +103,28 @@ HEADERS = {
     "X-Api-Key": API_KEY,
 }
 
+def read_student_data(tag):
+    """学生証からデータを読み取る（学生証でない場合はNone）"""
+    # TODO: 学生証のデータ構造に合わせて実装
+    # 例: NDEF読み取り、特定ブロック読み取りなど
+    return None
+
 def on_card_touch(tag):
     card_uid = tag.identifier.hex().upper()
     print(f"カード検出: {card_uid}")
 
+    payload = {"card_uid": card_uid}
+
+    # 学生証データが読み取れたら追加（任意）
+    student_data = read_student_data(tag)
+    if student_data:
+        payload["student_id"] = student_data.get("student_id")
+        payload["student_name"] = student_data.get("student_name")
+
     try:
         response = requests.post(
             API_URL,
-            json={"card_uid": card_uid},
+            json=payload,
             headers=HEADERS,
             timeout=10,
         )

--- a/docs/nfc_raspi_guide.md
+++ b/docs/nfc_raspi_guide.md
@@ -1,0 +1,135 @@
+# NFC Raspberry Pi 実装ガイド
+
+Raspi側の役割は **NFCカードのUIDを読み取り、Rails APIにPOSTする** だけです。
+入退室の判定・開閉室の制御・カード登録などのロジックは全てサーバー側で処理されます。
+
+---
+
+## 呼び出すAPI
+
+### `POST /api/rooms/:room_id/touch`
+
+| 項目 | 値 |
+|------|------|
+| メソッド | POST |
+| URL | `https://<アプリのドメイン>/api/rooms/:room_id/touch` |
+| 認証 | `X-Api-Key` ヘッダー |
+| Content-Type | `application/json` |
+
+`:room_id` は設置先の部室IDに置き換えてください（固定値）。
+
+### リクエスト
+
+```json
+{
+  "card_uid": "04A1B2C3D4E5F6"
+}
+```
+
+- `card_uid`: NFCカードから読み取ったUID（16進数文字列）
+
+### レスポンス
+
+**成功時（200 OK）:**
+
+```json
+{
+  "action": "enter",
+  "user": { "id": 1, "display_name": "田中太郎" },
+  "room": { "id": 3, "name": "第3部室" },
+  "timestamp": "2026-03-25T15:00:00+09:00"
+}
+```
+
+`action` の値:
+| action | 意味 |
+|--------|------|
+| `enter` | 入室した |
+| `exit` | 退室した |
+| `registration` | カード登録された（Webアプリから登録待ち中だった） |
+
+**エラー時（422 Unprocessable Entity）:**
+
+```json
+{
+  "error": "未登録のカードです"
+}
+```
+
+主なエラーメッセージ:
+- `未登録のカードです` — カードが未登録で、かつ登録待ちリクエストもない
+- `既にこの部室に入室中です` — 通常発生しない（トグルで処理するため）
+
+---
+
+## 環境変数
+
+Raspi側で必要な設定値:
+
+| 変数名 | 説明 | 例 |
+|--------|------|------|
+| `API_URL` | touch APIのURL | `https://example.com/api/rooms/3/touch` |
+| `API_KEY` | APIアクセストークン（サーバーの `API_ACCESS_TOKEN` と同じ値） | `your-secret-key` |
+
+---
+
+## Python実装例（nfcpy）
+
+```python
+import nfc
+import requests
+import os
+import time
+
+API_URL = os.environ["API_URL"]
+API_KEY = os.environ["API_KEY"]
+
+HEADERS = {
+    "Content-Type": "application/json",
+    "X-Api-Key": API_KEY,
+}
+
+def on_card_touch(tag):
+    card_uid = tag.identifier.hex().upper()
+    print(f"カード検出: {card_uid}")
+
+    try:
+        response = requests.post(
+            API_URL,
+            json={"card_uid": card_uid},
+            headers=HEADERS,
+            timeout=10,
+        )
+        data = response.json()
+
+        if response.ok:
+            action = data["action"]
+            user = data["user"]["display_name"]
+            print(f"{action}: {user}")
+        else:
+            print(f"エラー: {data.get('error', '不明なエラー')}")
+    except requests.RequestException as e:
+        print(f"通信エラー: {e}")
+
+    # カードが離れるまで待つ（連続読み取り防止）
+    return True
+
+def main():
+    with nfc.ContactlessFrontend("usb") as clf:
+        print("NFCリーダー起動。カードをかざしてください...")
+        while True:
+            clf.connect(rdwr={"on-connect": on_card_touch})
+            time.sleep(0.5)
+
+if __name__ == "__main__":
+    main()
+```
+
+---
+
+## 注意事項
+
+- **Raspi側にロジックは不要**です。カードUIDをPOSTするだけでサーバーが入室/退室/登録を自動判定します。
+- **連続読み取りの防止**を必ず実装してください。同じカードが短時間に何度も送信されると入室→退室が繰り返されます。
+- **通信エラー時はリトライせず無視**してOKです。次にカードをかざせば再送信されます。
+- `card_uid` の形式（大文字/小文字、区切り文字の有無）はサーバー側と統一してください。上記の例では大文字16進数（`04A1B2C3D4E5F6`）を使用しています。

--- a/docs/nfc_raspi_guide.md
+++ b/docs/nfc_raspi_guide.md
@@ -44,13 +44,24 @@ Raspi側の役割は **NFCカードのUIDを読み取り、Rails APIにPOSTす�
 
 ### レスポンス
 
-**成功時（200 OK）:**
+**入室/退室時（200 OK）:**
 
 ```json
 {
   "action": "enter",
   "user": { "id": 1, "display_name": "田中太郎" },
   "room": { "id": 3, "name": "第3部室" },
+  "timestamp": "2026-03-25T15:00:00+09:00"
+}
+```
+
+**カード登録時（200 OK）:**
+
+```json
+{
+  "action": "registration",
+  "user": { "id": 1, "display_name": "田中太郎" },
+  "card_uid": "04A1B2C3D4E5F6",
   "timestamp": "2026-03-25T15:00:00+09:00"
 }
 ```

--- a/docs/nfc_raspi_guide.md
+++ b/docs/nfc_raspi_guide.md
@@ -139,7 +139,7 @@ def on_card_touch(tag):
     except requests.RequestException as e:
         print(f"通信エラー: {e}")
 
-    # カードが離れるまで待つ（連続読み取り防止）
+    # Trueを返すとカードが離れるまで次の読み取りをしない（連続読み取り防止）
     return True
 
 def main():


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * NFCカードの登録・管理フローを追加（開始・確認・取消・削除）
  * NFCタッチ送信による出退室/登録判定APIを追加（端末からのタッチで入退室または登録フローを返す）
  * ユーザーメニューに「NFCカード」管理リンクと未登録時のバッジを表示
  * ユーザーあたり1枚のみ登録可能に制限

* **ドキュメント**
  * Raspberry Pi を使った NFC リーダー連携ガイドを公開しました
<!-- end of auto-generated comment: release notes by coderabbit.ai -->