### PR TITLE
アプリアイコン表示＋ホーム画面UIブラッシュアップ

### DIFF
--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -27,7 +27,7 @@
         <h3 class="text-lg font-bold text-gray-800 mb-4"><%= room.name %></h3>
         
         <% if room.keys.any? %>
-          <div class="flex flex-wrap gap-x-2 gap-y-2 pb-1 md:hidden">
+          <div class="flex flex-wrap gap-x-1 min-[390px]:gap-x-2 gap-y-2 pb-1 md:hidden">
             <% room.keys.each do |key| %>
               <div class="w-14 flex flex-col items-center gap-1">
                 <%= render(UserAvatarComponent.new(user: key.user, size: :medium)) %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -23,26 +23,27 @@
   <%# Key Holders %>
   <div class="grid gap-4 grid-cols-1 md:grid-cols-3">
     <% @rooms.each do |room| %>
+      <% assigned_keys = room.keys.select { |key| key.user.present? } %>
       <div class="card p-5">
         <h3 class="text-lg font-bold text-gray-800 mb-4"><%= room.name %></h3>
         
-        <% if room.keys.any? %>
+        <% if assigned_keys.any? %>
           <div class="flex flex-wrap gap-x-1 min-[390px]:gap-x-2 gap-y-2 pb-1 md:hidden">
-            <% room.keys.each do |key| %>
+            <% assigned_keys.each do |key| %>
               <div class="w-14 flex flex-col items-center gap-1">
                 <%= render(UserAvatarComponent.new(user: key.user, size: :medium)) %>
-                <p class="w-full text-xs text-gray-600 leading-none text-center truncate"><%= key.user&.display_name || "Unknown" %></p>
+                <p class="w-full text-xs text-gray-600 leading-none text-center truncate"><%= key.user.display_name %></p>
               </div>
             <% end %>
           </div>
 
           <div class="hidden md:flex md:flex-wrap md:gap-2">
-            <% room.keys.each do |key| %>
+            <% assigned_keys.each do |key| %>
               <div class="relative group cursor-pointer">
                 <%= render(UserAvatarComponent.new(user: key.user, size: :medium)) %>
 
                 <div class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-2 py-1 bg-gray-800 text-white text-xs rounded opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap pointer-events-none z-10">
-                  <%= key.user&.display_name || "Unknown" %>
+                  <%= key.user.display_name %>
                 </div>
               </div>
             <% end %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -26,22 +26,30 @@
       <div class="card p-5">
         <h3 class="text-lg font-bold text-gray-800 mb-4"><%= room.name %></h3>
         
-        <div class="flex flex-wrap gap-2">
-          <% if room.keys.any? %>
+        <% if room.keys.any? %>
+          <div class="flex flex-wrap gap-x-1 gap-y-2 pb-1 md:hidden">
+            <% room.keys.each do |key| %>
+              <div class="w-14 flex flex-col items-center gap-1">
+                <%= render(UserAvatarComponent.new(user: key.user, size: :medium)) %>
+                <p class="w-full text-xs text-gray-600 leading-none text-center truncate"><%= key.user&.display_name || "Unknown" %></p>
+              </div>
+            <% end %>
+          </div>
+
+          <div class="hidden md:flex md:flex-wrap md:gap-2">
             <% room.keys.each do |key| %>
               <div class="relative group cursor-pointer">
                 <%= render(UserAvatarComponent.new(user: key.user, size: :medium)) %>
-                
-                <%# Tooltip %>
+
                 <div class="absolute bottom-full left-1/2 -translate-x-1/2 mb-2 px-2 py-1 bg-gray-800 text-white text-xs rounded opacity-0 group-hover:opacity-100 transition-opacity whitespace-nowrap pointer-events-none z-10">
                   <%= key.user&.display_name || "Unknown" %>
                 </div>
               </div>
             <% end %>
-          <% else %>
-            <p class="text-sm text-gray-400">鍵持ちはいません</p>
-          <% end %>
-        </div>
+          </div>
+        <% else %>
+          <p class="text-sm text-gray-400">鍵持ちはいません</p>
+        <% end %>
       </div>
     <% end %>
   </div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -27,7 +27,7 @@
         <h3 class="text-lg font-bold text-gray-800 mb-4"><%= room.name %></h3>
         
         <% if room.keys.any? %>
-          <div class="flex flex-wrap gap-x-1 gap-y-2 pb-1 md:hidden">
+          <div class="flex flex-wrap gap-x-2 gap-y-2 pb-1 md:hidden">
             <% room.keys.each do |key| %>
               <div class="w-14 flex flex-col items-center gap-1">
                 <%= render(UserAvatarComponent.new(user: key.user, size: :medium)) %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -50,7 +50,10 @@
     <!-- Desktop Sidebar -->
     <aside class="hidden md:flex flex-col w-64 h-screen fixed top-0 left-0 bg-white border-r border-gray-200 z-30">
       <div class="h-16 flex items-center px-6 border-b border-gray-100">
-        <span class="text-xl font-bold text-gray-800">Jyogi Rooms</span>
+        <div class="flex items-center gap-2">
+          <%= image_tag "/JyogiRoomsIcon.webp", alt: "Jyogi Rooms Icon", class: "w-9 h-9 rounded" %>
+          <span class="text-xl font-bold text-gray-800">Jyogi Rooms</span>
+        </div>
       </div>
       <nav class="flex-1 px-4 py-6 space-y-1">
         <% nav_items.each do |item| %>
@@ -97,7 +100,10 @@
 
     <!-- Mobile Header (Optional, for brand) -->
     <header class="md:hidden fixed top-0 left-0 w-full h-14 bg-white border-b border-gray-200 flex items-center justify-between px-4 z-30">
-      <span class="text-xl font-bold text-gray-800">Jyogi Rooms</span>
+      <div class="flex items-center gap-2">
+        <%= image_tag "/JyogiRoomsIcon.webp", alt: "Jyogi Rooms Icon", class: "w-8 h-8 rounded" %>
+        <span class="text-xl font-bold text-gray-800">Jyogi Rooms</span>
+      </div>
       <!-- Mobile User Menu (checkbox toggle for real mobile support) -->
       <div class="relative">
         <input type="checkbox" id="mobile-menu-toggle" class="peer hidden">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -50,10 +50,7 @@
     <!-- Desktop Sidebar -->
     <aside class="hidden md:flex flex-col w-64 h-screen fixed top-0 left-0 bg-white border-r border-gray-200 z-30">
       <div class="h-16 flex items-center px-6 border-b border-gray-100">
-        <div class="flex items-center gap-2">
-          <%= image_tag "/JyogiRoomsIcon.webp", alt: "Jyogi Rooms Icon", class: "w-12 h-12 rounded-full object-cover" %>
-          <span class="text-xl font-bold text-gray-800">Jyogi Rooms</span>
-        </div>
+        <%= render "shared/app_brand", size_class: "w-12 h-12 rounded-full object-cover" %>
       </div>
       <nav class="flex-1 px-4 py-6 space-y-1">
         <% nav_items.each do |item| %>
@@ -100,10 +97,7 @@
 
     <!-- Mobile Header (Optional, for brand) -->
     <header class="md:hidden fixed top-0 left-0 w-full h-14 bg-white border-b border-gray-200 flex items-center justify-between px-4 z-30">
-      <div class="flex items-center gap-2">
-        <%= image_tag "/JyogiRoomsIcon.webp", alt: "Jyogi Rooms Icon", class: "w-11 h-11 rounded-full object-cover" %>
-        <span class="text-xl font-bold text-gray-800">Jyogi Rooms</span>
-      </div>
+      <%= render "shared/app_brand", size_class: "w-11 h-11 rounded-full object-cover" %>
       <!-- Mobile User Menu (checkbox toggle for real mobile support) -->
       <div class="relative">
         <input type="checkbox" id="mobile-menu-toggle" class="peer hidden">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,7 +51,7 @@
     <aside class="hidden md:flex flex-col w-64 h-screen fixed top-0 left-0 bg-white border-r border-gray-200 z-30">
       <div class="h-16 flex items-center px-6 border-b border-gray-100">
         <div class="flex items-center gap-2">
-          <%= image_tag "/JyogiRoomsIcon.webp", alt: "Jyogi Rooms Icon", class: "w-12 h-12 rounded-full border border-gray-200 object-cover" %>
+          <%= image_tag "/JyogiRoomsIcon.webp", alt: "Jyogi Rooms Icon", class: "w-12 h-12 rounded-full object-cover" %>
           <span class="text-xl font-bold text-gray-800">Jyogi Rooms</span>
         </div>
       </div>
@@ -101,7 +101,7 @@
     <!-- Mobile Header (Optional, for brand) -->
     <header class="md:hidden fixed top-0 left-0 w-full h-14 bg-white border-b border-gray-200 flex items-center justify-between px-4 z-30">
       <div class="flex items-center gap-2">
-        <%= image_tag "/JyogiRoomsIcon.webp", alt: "Jyogi Rooms Icon", class: "w-11 h-11 rounded-full border border-gray-200 object-cover" %>
+        <%= image_tag "/JyogiRoomsIcon.webp", alt: "Jyogi Rooms Icon", class: "w-11 h-11 rounded-full object-cover" %>
         <span class="text-xl font-bold text-gray-800">Jyogi Rooms</span>
       </div>
       <!-- Mobile User Menu (checkbox toggle for real mobile support) -->

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -51,7 +51,7 @@
     <aside class="hidden md:flex flex-col w-64 h-screen fixed top-0 left-0 bg-white border-r border-gray-200 z-30">
       <div class="h-16 flex items-center px-6 border-b border-gray-100">
         <div class="flex items-center gap-2">
-          <%= image_tag "/JyogiRoomsIcon.webp", alt: "Jyogi Rooms Icon", class: "w-9 h-9 rounded" %>
+          <%= image_tag "/JyogiRoomsIcon.webp", alt: "Jyogi Rooms Icon", class: "w-12 h-12 rounded-full border border-gray-200 object-cover" %>
           <span class="text-xl font-bold text-gray-800">Jyogi Rooms</span>
         </div>
       </div>
@@ -101,7 +101,7 @@
     <!-- Mobile Header (Optional, for brand) -->
     <header class="md:hidden fixed top-0 left-0 w-full h-14 bg-white border-b border-gray-200 flex items-center justify-between px-4 z-30">
       <div class="flex items-center gap-2">
-        <%= image_tag "/JyogiRoomsIcon.webp", alt: "Jyogi Rooms Icon", class: "w-8 h-8 rounded" %>
+        <%= image_tag "/JyogiRoomsIcon.webp", alt: "Jyogi Rooms Icon", class: "w-11 h-11 rounded-full border border-gray-200 object-cover" %>
         <span class="text-xl font-bold text-gray-800">Jyogi Rooms</span>
       </div>
       <!-- Mobile User Menu (checkbox toggle for real mobile support) -->

--- a/app/views/shared/_app_brand.html.erb
+++ b/app/views/shared/_app_brand.html.erb
@@ -1,0 +1,4 @@
+<div class="flex items-center gap-2">
+  <%= image_tag "/JyogiRoomsIcon.webp", alt: "Jyogi Rooms Icon", class: size_class %>
+  <span class="text-xl font-bold text-gray-800">Jyogi Rooms</span>
+</div>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * ダッシュボードの「キー保有者」カードをレスポンシブ対応に改善。小画面ではコンパクトなリスト表示、中規模以上の画面ではツールチップ付きアイコン表示に対応
  * ヘッダーにアプリアイコンを追加。デスクトップ・モバイル両方で「Jyogi Rooms」テキストの隣に表示

<!-- end of auto-generated comment: release notes by coderabbit.ai -->