### PR TITLE
管理者表示の切り替え機能＋鍵持ち管理画面の表示を鍵持ち/管理者に限定

### DIFF
--- a/app/controllers/admin/base_controller.rb
+++ b/app/controllers/admin/base_controller.rb
@@ -4,7 +4,7 @@ class Admin::BaseController < ApplicationController
   private
 
   def require_admin!
-    unless current_user&.admin?
+    unless effective_admin?
       redirect_to root_path, alert: "権限がありません"
     end
   end

--- a/app/controllers/admin_disguise_controller.rb
+++ b/app/controllers/admin_disguise_controller.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class AdminDisguiseController < ApplicationController
+  before_action :require_real_admin!
+
+  # POST /admin_disguise/toggle
+  def toggle
+    session[:admin_disguise] = !session[:admin_disguise]
+    redirect_back fallback_location: root_path
+  end
+
+  private
+
+  def require_real_admin!
+    unless current_user&.admin?
+      redirect_to root_path, alert: "権限がありません"
+    end
+  end
+end

--- a/app/controllers/admin_disguise_controller.rb
+++ b/app/controllers/admin_disguise_controller.rb
@@ -6,7 +6,13 @@ class AdminDisguiseController < ApplicationController
   # POST /admin_disguise/toggle
   def toggle
     session[:admin_disguise] = !session[:admin_disguise]
-    redirect_back fallback_location: root_path
+
+    if session[:admin_disguise]
+      # 偽装ON: 管理画面にいると権限エラーになるためルートに遷移
+      redirect_to root_path
+    else
+      redirect_back fallback_location: root_path
+    end
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,5 +5,10 @@ class ApplicationController < ActionController::Base
   include JyogiAuthenticatable
 
   # ビューでもcurrent_userを使えるようにする
-  helper_method :current_user, :user_signed_in?
+  helper_method :current_user, :user_signed_in?, :effective_admin?
+
+  # 管理者偽装モード中はfalseを返す（実際のDB権限は変更しない）
+  def effective_admin?
+    current_user&.admin? && !session[:admin_disguise]
+  end
 end

--- a/app/controllers/keys_controller.rb
+++ b/app/controllers/keys_controller.rb
@@ -1,5 +1,6 @@
 class KeysController < ApplicationController
   before_action :authenticate_user!, only: [ :index, :transfer_form, :transfer, :assign_form, :assign, :unassign ]
+  before_action :require_key_holder_or_admin!, only: [ :index ]
   before_action :set_room, only: [ :transfer_form, :transfer, :assign_form, :assign, :unassign ]
   before_action :require_admin!, only: [ :assign_form, :assign, :unassign ]
 
@@ -131,6 +132,12 @@ class KeysController < ApplicationController
 
       redirect_to keys_path, alert: "権限がありません"
       nil
+    end
+  end
+
+  def require_key_holder_or_admin!
+    unless effective_admin? || current_user.keys.exists?
+      redirect_to root_path, alert: "鍵持ちまたは管理者のみアクセスできます"
     end
   end
 

--- a/app/controllers/keys_controller.rb
+++ b/app/controllers/keys_controller.rb
@@ -124,7 +124,7 @@ class KeysController < ApplicationController
   def resolve_from_user
     from_user_id = params[:from_user_id]
 
-    if current_user.admin?
+    if effective_admin?
       User.find(from_user_id)
     else
       return current_user if from_user_id.blank? || from_user_id.to_i == current_user.id
@@ -135,7 +135,7 @@ class KeysController < ApplicationController
   end
 
   def require_admin!
-    unless current_user.admin?
+    unless effective_admin?
       redirect_to keys_path, alert: "権限がありません"
     end
   end

--- a/app/controllers/room_statuses_controller.rb
+++ b/app/controllers/room_statuses_controller.rb
@@ -59,7 +59,7 @@ class RoomStatusesController < ApplicationController
   end
 
   def can_close?(room)
-    return true if current_user.admin?
+    return true if effective_admin?
 
     current_user.keys.any? { |key| key.room_id == room.id }
   end

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -3,10 +3,15 @@ module NavigationHelper
     items = [
       { path: root_path, icon: :home, label: "ホーム", active: current_page?(root_path) },
       { path: room_statuses_path, icon: :door, label: "部室状況", active: current_page?(room_statuses_path) },
-      { path: reservations_path, icon: :calendar, label: "部室予約", active: current_page?(reservations_path) },
-      { path: keys_path, icon: :key, label: "鍵管理", active: current_page?(keys_path) },
-      { path: stats_me_path, icon: :chart, label: "統計", active: controller_name == "stats" }
+      { path: reservations_path, icon: :calendar, label: "部室予約", active: current_page?(reservations_path) }
     ]
+
+    # 鍵持ちまたは管理者のみ鍵管理を表示
+    if effective_admin? || current_user&.keys&.exists?
+      items << { path: keys_path, icon: :key, label: "鍵管理", active: current_page?(keys_path) }
+    end
+
+    items << { path: stats_me_path, icon: :chart, label: "統計", active: controller_name == "stats" }
 
     # 管理者のみ管理画面へのリンクを表示
     if effective_admin?

--- a/app/helpers/navigation_helper.rb
+++ b/app/helpers/navigation_helper.rb
@@ -9,7 +9,7 @@ module NavigationHelper
     ]
 
     # 管理者のみ管理画面へのリンクを表示
-    if current_user&.admin?
+    if effective_admin?
       items << { path: admin_roles_path, icon: :shield, label: "管理画面", active: controller_path.start_with?("admin/") }
     end
 

--- a/app/views/keys/index.html.erb
+++ b/app/views/keys/index.html.erb
@@ -35,11 +35,11 @@
                   <p class="text-xs text-gray-700 font-medium text-center line-clamp-2" title="<%= key.user&.display_name %>">
                     <%= key.user&.display_name %>
                   </p>
-                  <% if current_user.admin? || key.user_id == current_user.id %>
+                  <% if effective_admin? || key.user_id == current_user.id %>
                     <%= link_to "譲渡", transfer_form_room_key_path(room.id, from_user_id: key.user_id),
                         class: "w-full px-3 py-1.5 bg-primary text-white text-xs font-medium rounded-md text-center hover:bg-primary-dark transition-colors" %>
                   <% end %>
-                  <% if current_user.admin? %>
+                  <% if effective_admin? %>
                     <%= button_to "解除", unassign_room_key_path(room.id, user_id: key.user_id),
                         method: :post,
                         form: { onsubmit: "return confirm('#{j(key.user&.display_name.to_s)} の鍵の割り当てを解除しますか？')" },
@@ -53,7 +53,7 @@
           </div>
         </div>
 
-        <% if current_user.admin? && room.keys.any? { |k| k.user_id.nil? } %>
+        <% if effective_admin? && room.keys.any? { |k| k.user_id.nil? } %>
           <div class="flex items-center justify-between">
             <p class="text-sm text-gray-500">未割り当ての鍵: <%= room.keys.count { |k| k.user_id.nil? } %>本</p>
             <%= link_to "割り当て", assign_form_room_key_path(room.id),

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -75,7 +75,18 @@
           </button>
           <!-- Dropdown Menu -->
           <div class="absolute bottom-full left-4 right-4 mb-2 bg-white border border-gray-200 rounded-lg shadow-lg opacity-0 invisible group-focus-within:opacity-100 group-focus-within:visible transition-all duration-200">
-            <%= link_to nfc_cards_path, class: "w-full flex items-center gap-3 px-4 py-3 text-gray-700 hover:bg-gray-50 rounded-t-lg transition-colors" do %>
+            <% if current_user&.admin? %>
+              <%= button_to toggle_admin_disguise_path, method: :post, class: "w-full flex items-center gap-3 px-4 py-3 text-gray-700 hover:bg-gray-50 rounded-t-lg transition-colors border-b border-gray-100" do %>
+                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                  <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z"></path>
+                </svg>
+                <span class="text-sm font-medium">管理者表示</span>
+                <span class="ml-auto text-xs font-medium <%= session[:admin_disguise] ? 'text-gray-400' : 'text-green-600' %>">
+                  <%= session[:admin_disguise] ? "OFF" : "ON" %>
+                </span>
+              <% end %>
+            <% end %>
+            <%= link_to nfc_cards_path, class: "w-full flex items-center gap-3 px-4 py-3 text-gray-700 hover:bg-gray-50 #{current_user&.admin? ? '' : 'rounded-t-lg'} transition-colors" do %>
               <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.5 1.5H8.25A2.25 2.25 0 006 3.75v16.5a2.25 2.25 0 002.25 2.25h7.5A2.25 2.25 0 0018 20.25V3.75a2.25 2.25 0 00-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3m-3 18.75h3"></path>
               </svg>
@@ -115,6 +126,17 @@
             <p class="text-sm font-bold text-gray-800"><%= current_user ? current_user.display_name : "Guest" %></p>
             <p class="text-xs text-gray-500">@<%= current_user ? current_user.username : "guest" %></p>
           </div>
+          <% if current_user&.admin? %>
+            <%= button_to toggle_admin_disguise_path, method: :post, class: "w-full flex items-center gap-3 px-4 py-3 text-gray-700 hover:bg-gray-50 transition-colors border-b border-gray-100" do %>
+              <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12.75 11.25 15 15 9.75m-3-7.036A11.959 11.959 0 0 1 3.598 6 11.99 11.99 0 0 0 3 9.749c0 5.592 3.824 10.29 9 11.623 5.176-1.332 9-6.03 9-11.622 0-1.31-.21-2.571-.598-3.751h-.152c-3.196 0-6.1-1.248-8.25-3.285Z"></path>
+              </svg>
+              <span class="text-sm font-medium">管理者表示</span>
+              <span class="ml-auto text-xs font-medium <%= session[:admin_disguise] ? 'text-gray-400' : 'text-green-600' %>">
+                <%= session[:admin_disguise] ? "OFF" : "ON" %>
+              </span>
+            <% end %>
+          <% end %>
           <%= link_to nfc_cards_path, class: "w-full flex items-center gap-3 px-4 py-3 text-gray-700 hover:bg-gray-50 transition-colors" do %>
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.5 1.5H8.25A2.25 2.25 0 006 3.75v16.5a2.25 2.25 0 002.25 2.25h7.5A2.25 2.25 0 0018 20.25V3.75a2.25 2.25 0 00-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3m-3 18.75h3"></path>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   resources :reservations, except: [ :show ]
   resources :keys, only: [ :index ]
   resources :nfc_cards, only: %i[index destroy]
+  post "admin_disguise/toggle", to: "admin_disguise#toggle", as: :toggle_admin_disguise
   get "stats/ranking", to: "stats#ranking", as: :stats_ranking
   get "stats/me", to: "stats#me", as: :stats_me
   resources :room_statuses, only: %i[index] do


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ユーザーメニューに「管理者表示」トグルを追加し、管理者モードをON/OFFできるようになりました（表示ステータスを明示）。

* **Improvements**
  * 管理者判定を統一したロジックに更新し、表示・操作の一貫性を向上しました。
  * 鍵管理や管理画面、ナビゲーションの表示制御を改善し、権限に応じたリンクや操作の可視性を調整しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->