### PR TITLE
UIのブラッシュアップ

### DIFF
--- a/app/components/calendar/day_component.html.erb
+++ b/app/components/calendar/day_component.html.erb
@@ -24,10 +24,10 @@
           <%= helpers.format_time_short(res.start_at) %><span class="hidden md:inline">~<%= helpers.format_time_short(res.end_at) %></span>
         </span>
         <div class="md:hidden flex-shrink-0 ml-0.5">
-          <%= render UserAvatarComponent.new(user: res.user, size: :xxs, extra_classes: "border-0 shadow-none") %>
+          <%= render UserAvatarComponent.new(user: res.user, size: :xxs, borderless: true, flat: true) %>
         </div>
         <div class="hidden md:block flex-shrink-0">
-          <%= render UserAvatarComponent.new(user: res.user, size: :xs, extra_classes: "border-0 shadow-none") %>
+          <%= render UserAvatarComponent.new(user: res.user, size: :xs, borderless: true, flat: true) %>
         </div>
       </div>
     <% end %>

--- a/app/components/calendar/day_component.html.erb
+++ b/app/components/calendar/day_component.html.erb
@@ -19,7 +19,7 @@
   <!-- Reservations List -->
   <div class="flex-1 flex flex-col gap-0.5 md:gap-1 overflow-hidden mt-0.5 md:mt-1 px-0.5 md:px-1">
     <% day_reservations.each do |res| %>
-      <div class="text-[10px] bg-indigo-50 text-indigo-700 border-l-2 border-indigo-500 pl-0.5 md:pl-1 pr-0.5 py-0.5 rounded-sm flex items-center justify-between group/res shadow-sm hover:shadow-md transition-shadow cursor-default">
+      <div class="text-[10px] bg-indigo-50 text-indigo-700 pl-0.5 md:pl-1 pr-0.5 py-0.5 rounded-sm flex items-center justify-between group/res shadow-sm hover:shadow-md transition-shadow cursor-default">
         <span class="font-bold md:truncate md:mr-1 whitespace-nowrap leading-tight w-full md:w-auto">
           <%= helpers.format_time_short(res.start_at) %>~<span class="hidden md:inline"><%= helpers.format_time_short(res.end_at) %></span>
         </span>

--- a/app/components/calendar/day_component.html.erb
+++ b/app/components/calendar/day_component.html.erb
@@ -21,8 +21,11 @@
     <% day_reservations.each do |res| %>
       <div class="text-[10px] bg-indigo-50 text-indigo-700 pl-0.5 md:pl-1 pr-0.5 py-0.5 rounded-sm flex items-center justify-between group/res shadow-sm hover:shadow-md transition-shadow cursor-default">
         <span class="font-bold md:truncate md:mr-1 whitespace-nowrap leading-tight w-full md:w-auto">
-          <%= helpers.format_time_short(res.start_at) %>~<span class="hidden md:inline"><%= helpers.format_time_short(res.end_at) %></span>
+          <%= helpers.format_time_short(res.start_at) %><span class="hidden md:inline">~<%= helpers.format_time_short(res.end_at) %></span>
         </span>
+        <div class="md:hidden flex-shrink-0 ml-0.5">
+          <%= render UserAvatarComponent.new(user: res.user, size: :xxs, extra_classes: "border-0 shadow-none") %>
+        </div>
         <div class="hidden md:block flex-shrink-0">
           <%= render UserAvatarComponent.new(user: res.user, size: :xs, extra_classes: "border-0 shadow-none") %>
         </div>

--- a/app/components/user_avatar_component.rb
+++ b/app/components/user_avatar_component.rb
@@ -30,14 +30,14 @@ class UserAvatarComponent < ViewComponent::Base
 
   def container_classes
     base = "rounded-full flex items-center justify-center font-bold"
-    "#{base} #{size_classes} #{shadow_class} #{bg_color_class} #{@extra_classes}"
+    "#{base} #{size_classes} #{shadow_class} #{bg_and_border_classes} #{@extra_classes}"
   end
 
   def image_classes
     "#{size_classes} rounded-full object-cover #{shadow_class} #{@extra_classes}"
   end
 
-  def bg_color_class
+  def bg_and_border_classes
     border_class = @borderless ? "" : "border-2 border-white"
     "bg-gray-200 text-gray-500 #{border_class}"
   end

--- a/app/components/user_avatar_component.rb
+++ b/app/components/user_avatar_component.rb
@@ -1,8 +1,10 @@
 class UserAvatarComponent < ViewComponent::Base
-  def initialize(user:, size: :medium, extra_classes: "")
+  def initialize(user:, size: :medium, extra_classes: "", borderless: false, flat: false)
     @user = user
     @size = size
     @extra_classes = extra_classes
+    @borderless = borderless
+    @flat = flat
   end
 
   private
@@ -27,16 +29,21 @@ class UserAvatarComponent < ViewComponent::Base
   end
 
   def container_classes
-    base = "rounded-full flex items-center justify-center font-bold shadow-sm"
-    "#{base} #{size_classes} #{bg_color_class} #{@extra_classes}"
+    base = "rounded-full flex items-center justify-center font-bold"
+    "#{base} #{size_classes} #{shadow_class} #{bg_color_class} #{@extra_classes}"
   end
 
   def image_classes
-    "#{size_classes} rounded-full object-cover shadow-sm #{@extra_classes}"
+    "#{size_classes} rounded-full object-cover #{shadow_class} #{@extra_classes}"
   end
 
   def bg_color_class
-    "bg-gray-200 text-gray-500 border-2 border-white"
+    border_class = @borderless ? "" : "border-2 border-white"
+    "bg-gray-200 text-gray-500 #{border_class}"
+  end
+
+  def shadow_class
+    @flat ? "" : "shadow-sm"
   end
 
   def initial

--- a/app/components/user_avatar_component.rb
+++ b/app/components/user_avatar_component.rb
@@ -9,6 +9,8 @@ class UserAvatarComponent < ViewComponent::Base
 
   def size_classes
     case @size
+    when :xxs
+      "w-3 h-3 text-[7px]"
     when :xs
       "w-6 h-6 text-[10px]"
     when :small

--- a/app/helpers/keys_helper.rb
+++ b/app/helpers/keys_helper.rb
@@ -1,0 +1,9 @@
+module KeysHelper
+  def key_transferable?(key)
+    effective_admin? || key.user_id == current_user&.id
+  end
+
+  def key_unassignable?(key)
+    effective_admin?
+  end
+end

--- a/app/views/admin/key_transfer_logs/index.html.erb
+++ b/app/views/admin/key_transfer_logs/index.html.erb
@@ -1,5 +1,5 @@
 <div class="space-y-6 px-4 py-6 md:px-8">
-<h1 class="text-2xl font-bold text-gray-900">管理画面</h1>
+<h1 class="text-2xl font-bold text-gray-900">🛡️ 管理画面</h1>
 
 <%= render "admin/nav" %>
 

--- a/app/views/admin/roles/index.html.erb
+++ b/app/views/admin/roles/index.html.erb
@@ -1,5 +1,5 @@
 <div class="space-y-6 px-4 py-6 md:px-8">
-<h1 class="text-2xl font-bold text-gray-900">管理画面</h1>
+<h1 class="text-2xl font-bold text-gray-900">🛡️ 管理画面</h1>
 
 <%= render "admin/nav" %>
 

--- a/app/views/admin/roles/show.html.erb
+++ b/app/views/admin/roles/show.html.erb
@@ -1,5 +1,5 @@
 <div class="space-y-6 px-4 py-6 md:px-8">
-<h1 class="text-2xl font-bold text-gray-900">管理画面</h1>
+<h1 class="text-2xl font-bold text-gray-900">🛡️ 管理画面</h1>
 
 <%= render "admin/nav" %>
 

--- a/app/views/admin/scheduled_announcements/edit.html.erb
+++ b/app/views/admin/scheduled_announcements/edit.html.erb
@@ -1,5 +1,5 @@
 <div class="space-y-6 px-4 py-6 md:px-8">
-<h1 class="text-2xl font-bold text-gray-900">管理画面</h1>
+<h1 class="text-2xl font-bold text-gray-900">🛡️ 管理画面</h1>
 
 <%= render "admin/nav" %>
 

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -1,5 +1,5 @@
 <div class="space-y-6 px-4 py-6 md:px-8">
-<h1 class="text-2xl font-bold text-gray-900">管理画面</h1>
+<h1 class="text-2xl font-bold text-gray-900">🛡️ 管理画面</h1>
 
 <%= render "admin/nav" %>
 

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -1,5 +1,5 @@
 <div class="space-y-6 px-4 py-6 md:px-8">
-  <h2 class="text-xl font-bold text-gray-800">部室状況</h2>
+  <h2 class="text-xl font-bold text-gray-800">🚪 部室状況</h2>
 
   <div class="grid gap-4 grid-cols-1 md:grid-cols-3">
     <% @room_statuses.each do |data| %>
@@ -37,7 +37,7 @@
 
   <div class="h-px bg-gray-200 my-6"></div>
 
-    <h2 class="text-xl font-bold text-gray-800">今日の予約</h2>
+  <h2 class="text-xl font-bold text-gray-800">📅 今日の予約</h2>
 
   <%# Today's Reservations %>
   <div class="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
@@ -55,7 +55,7 @@
   <div class="h-px bg-gray-200 my-6"></div>
 
   <div class="flex items-center justify-between mb-4">
-    <h2 class="text-xl font-bold text-gray-800">現在の鍵持ち</h2>
+    <h2 class="text-xl font-bold text-gray-800">🔑 現在の鍵持ち</h2>
   </div>
 
   <%# Key Holders %>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -68,9 +68,9 @@
         <% if assigned_keys.any? %>
           <div class="flex flex-wrap gap-x-1 min-[390px]:gap-x-2 gap-y-2 pb-1 md:hidden">
             <% assigned_keys.each do |key| %>
-              <div class="w-14 flex flex-col items-center gap-1">
+              <div class="w-14 flex flex-col items-center gap-2">
                 <%= render(UserAvatarComponent.new(user: key.user, size: :medium)) %>
-                <p class="w-full text-xs text-gray-600 leading-none text-center truncate"><%= key.user.display_name %></p>
+                <p class="w-full text-xs text-gray-700 font-medium text-center line-clamp-2"><%= key.user.display_name %></p>
               </div>
             <% end %>
           </div>

--- a/app/views/keys/assign_form.html.erb
+++ b/app/views/keys/assign_form.html.erb
@@ -1,6 +1,6 @@
 <div class="space-y-6 px-4 py-6 md:px-8">
   <div class="flex items-center justify-between">
-    <h1 class="text-2xl font-bold text-gray-800">鍵の割り当て</h1>
+    <h1 class="text-2xl font-bold text-gray-800">🔑 鍵の割り当て</h1>
     <%= link_to "戻る", keys_path, class: "text-sm text-primary hover:text-primary-dark font-medium" %>
   </div>
 

--- a/app/views/keys/index.html.erb
+++ b/app/views/keys/index.html.erb
@@ -14,52 +14,51 @@
     </div>
   <% end %>
 
-  <!-- Key Holders Grid -->
-  <div class="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+  <!-- Key Holders -->
+  <div class="space-y-4">
     <% @rooms.each do |room| %>
-      <div class="card p-6">
-        <!-- Room Name -->
-        <h2 class="text-lg font-bold text-gray-800 mb-4"><%= room.name %></h2>
+      <div class="card p-5">
+        <div class="md:flex md:items-center md:gap-6">
+          <!-- Room Name -->
+          <h2 class="text-lg font-bold text-gray-800 mb-3 md:mb-0 md:w-28 md:shrink-0"><%= room.name %></h2>
 
-        <!-- Current Key Holder -->
-        <div class="mb-6 pb-6 border-b border-gray-200">
-          <p class="text-sm font-semibold text-gray-600 mb-3">現在の鍵持ち</p>
-          <div class="grid grid-cols-2 gap-3 md:grid-cols-3">
+          <!-- Key Holders -->
+          <div class="flex-1">
             <% assigned_keys = room.keys.select(&:user_id) %>
             <% if assigned_keys.any? %>
-              <% assigned_keys.each do |key| %>
-                <div class="bg-gray-50 rounded-lg p-3 border border-gray-200 flex flex-col items-center gap-2">
-                  <div class="relative group cursor-pointer">
+              <div class="grid grid-cols-2 gap-3 md:flex md:flex-wrap md:gap-3">
+                <% assigned_keys.each do |key| %>
+                  <div class="bg-gray-50 rounded-lg p-3 border border-gray-200 flex flex-col items-center gap-2 md:w-32">
                     <%= render(UserAvatarComponent.new(user: key.user, size: :small)) %>
+                    <p class="text-xs text-gray-700 font-medium text-center line-clamp-2" title="<%= key.user&.display_name %>">
+                      <%= key.user&.display_name %>
+                    </p>
+                    <% if effective_admin? || key.user_id == current_user.id %>
+                      <%= link_to "譲渡", transfer_form_room_key_path(room.id, from_user_id: key.user_id),
+                          class: "w-full px-3 py-1.5 bg-primary text-white text-xs font-medium rounded-md text-center hover:bg-primary-dark transition-colors" %>
+                    <% end %>
+                    <% if effective_admin? %>
+                      <%= button_to "解除", unassign_room_key_path(room.id, user_id: key.user_id),
+                          method: :post,
+                          form: { onsubmit: "return confirm('#{j(key.user&.display_name.to_s)} の鍵の割り当てを解除しますか？')" },
+                          class: "w-full px-3 py-1.5 bg-red-500 text-white text-xs font-medium rounded-md text-center hover:bg-red-600 transition-colors" %>
+                    <% end %>
                   </div>
-                  <p class="text-xs text-gray-700 font-medium text-center line-clamp-2" title="<%= key.user&.display_name %>">
-                    <%= key.user&.display_name %>
-                  </p>
-                  <% if effective_admin? || key.user_id == current_user.id %>
-                    <%= link_to "譲渡", transfer_form_room_key_path(room.id, from_user_id: key.user_id),
-                        class: "w-full px-3 py-1.5 bg-primary text-white text-xs font-medium rounded-md text-center hover:bg-primary-dark transition-colors" %>
-                  <% end %>
-                  <% if effective_admin? %>
-                    <%= button_to "解除", unassign_room_key_path(room.id, user_id: key.user_id),
-                        method: :post,
-                        form: { onsubmit: "return confirm('#{j(key.user&.display_name.to_s)} の鍵の割り当てを解除しますか？')" },
-                        class: "w-full px-3 py-1.5 bg-red-500 text-white text-xs font-medium rounded-md text-center hover:bg-red-600 transition-colors" %>
-                  <% end %>
-                </div>
-              <% end %>
+                <% end %>
+              </div>
             <% else %>
-              <p class="text-sm text-gray-400 col-span-full">未設定</p>
+              <p class="text-sm text-gray-400">未設定</p>
             <% end %>
           </div>
-        </div>
 
-        <% if effective_admin? && room.keys.any? { |k| k.user_id.nil? } %>
-          <div class="flex items-center justify-between">
-            <p class="text-sm text-gray-500">未割り当ての鍵: <%= room.keys.count { |k| k.user_id.nil? } %>本</p>
-            <%= link_to "割り当て", assign_form_room_key_path(room.id),
-                class: "px-4 py-2 bg-green-600 text-white text-sm font-medium rounded-md hover:bg-green-700 transition-colors" %>
-          </div>
-        <% end %>
+          <% if effective_admin? && room.keys.any? { |k| k.user_id.nil? } %>
+            <div class="mt-3 md:mt-0 md:shrink-0 flex items-center gap-2">
+              <p class="text-sm text-gray-500">未割り当て: <%= room.keys.count { |k| k.user_id.nil? } %>本</p>
+              <%= link_to "割り当て", assign_form_room_key_path(room.id),
+                  class: "px-4 py-2 bg-green-600 text-white text-sm font-medium rounded-md hover:bg-green-700 transition-colors" %>
+            </div>
+          <% end %>
+        </div>
       </div>
     <% end %>
   </div>

--- a/app/views/keys/index.html.erb
+++ b/app/views/keys/index.html.erb
@@ -17,6 +17,7 @@
   <!-- Key Holders -->
   <div class="space-y-4">
     <% @rooms.each do |room| %>
+      <% assigned_keys, unassigned_keys = room.keys.partition { |key| key.user_id.present? } %>
       <div class="card p-5">
         <div class="md:flex md:items-center md:gap-6">
           <!-- Room Name -->
@@ -24,12 +25,9 @@
 
           <!-- Key Holders -->
           <div class="flex-1">
-            <% assigned_keys = room.keys.select(&:user_id) %>
             <% if assigned_keys.any? %>
               <div class="grid grid-cols-2 gap-3 md:flex md:flex-wrap md:gap-3">
                 <% assigned_keys.each do |key| %>
-                  <% can_transfer = effective_admin? || key.user_id == current_user.id %>
-                  <% can_unassign = effective_admin? %>
                   <div class="bg-gray-50 rounded-lg p-3 border border-gray-200 flex flex-col md:w-36">
                     <div class="flex flex-col items-center gap-2">
                       <%= render(UserAvatarComponent.new(user: key.user, size: :small)) %>
@@ -38,13 +36,13 @@
                       </p>
                     </div>
 
-                    <% if can_transfer || can_unassign %>
+                    <% if key_transferable?(key) || key_unassignable?(key) %>
                       <div class="mt-2 pt-2 border-t border-gray-200 flex items-center gap-2">
-                        <% if can_transfer %>
+                        <% if key_transferable?(key) %>
                           <%= link_to "譲渡", transfer_form_room_key_path(room.id, from_user_id: key.user_id),
                               class: "flex-1 px-2.5 py-1.5 bg-primary text-white text-xs font-medium rounded-md text-center hover:bg-primary-dark transition-colors" %>
                         <% end %>
-                        <% if can_unassign %>
+                        <% if key_unassignable?(key) %>
                           <%= button_to "解除", unassign_room_key_path(room.id, user_id: key.user_id),
                               method: :post,
                               form: { class: "flex-1", onsubmit: "return confirm('#{j(key.user&.display_name.to_s)} の鍵の割り当てを解除しますか？')" },
@@ -60,9 +58,9 @@
             <% end %>
           </div>
 
-          <% if effective_admin? && room.keys.any? { |k| k.user_id.nil? } %>
+          <% if effective_admin? && unassigned_keys.any? %>
             <div class="mt-3 md:mt-0 md:shrink-0 flex items-center gap-2">
-              <p class="text-sm text-gray-500">未割り当て: <%= room.keys.count { |k| k.user_id.nil? } %>本</p>
+              <p class="text-sm text-gray-500">未割り当て: <%= unassigned_keys.size %>本</p>
               <%= link_to "割り当て", assign_form_room_key_path(room.id),
                   class: "px-4 py-2 bg-green-600 text-white text-sm font-medium rounded-md hover:bg-green-700 transition-colors" %>
             </div>

--- a/app/views/keys/index.html.erb
+++ b/app/views/keys/index.html.erb
@@ -28,20 +28,29 @@
             <% if assigned_keys.any? %>
               <div class="grid grid-cols-2 gap-3 md:flex md:flex-wrap md:gap-3">
                 <% assigned_keys.each do |key| %>
-                  <div class="bg-gray-50 rounded-lg p-3 border border-gray-200 flex flex-col items-center gap-2 md:w-32">
-                    <%= render(UserAvatarComponent.new(user: key.user, size: :small)) %>
-                    <p class="text-xs text-gray-700 font-medium text-center line-clamp-2" title="<%= key.user&.display_name %>">
-                      <%= key.user&.display_name %>
-                    </p>
-                    <% if effective_admin? || key.user_id == current_user.id %>
-                      <%= link_to "譲渡", transfer_form_room_key_path(room.id, from_user_id: key.user_id),
-                          class: "w-full px-3 py-1.5 bg-primary text-white text-xs font-medium rounded-md text-center hover:bg-primary-dark transition-colors" %>
-                    <% end %>
-                    <% if effective_admin? %>
-                      <%= button_to "解除", unassign_room_key_path(room.id, user_id: key.user_id),
-                          method: :post,
-                          form: { onsubmit: "return confirm('#{j(key.user&.display_name.to_s)} の鍵の割り当てを解除しますか？')" },
-                          class: "w-full px-3 py-1.5 bg-red-500 text-white text-xs font-medium rounded-md text-center hover:bg-red-600 transition-colors" %>
+                  <% can_transfer = effective_admin? || key.user_id == current_user.id %>
+                  <% can_unassign = effective_admin? %>
+                  <div class="bg-gray-50 rounded-lg p-3 border border-gray-200 flex flex-col md:w-36">
+                    <div class="flex flex-col items-center gap-2">
+                      <%= render(UserAvatarComponent.new(user: key.user, size: :small)) %>
+                      <p class="text-xs text-gray-700 font-medium text-center line-clamp-2" title="<%= key.user&.display_name %>">
+                        <%= key.user&.display_name %>
+                      </p>
+                    </div>
+
+                    <% if can_transfer || can_unassign %>
+                      <div class="mt-2 pt-2 border-t border-gray-200 flex items-center gap-2">
+                        <% if can_transfer %>
+                          <%= link_to "譲渡", transfer_form_room_key_path(room.id, from_user_id: key.user_id),
+                              class: "flex-1 px-2.5 py-1.5 bg-primary text-white text-xs font-medium rounded-md text-center hover:bg-primary-dark transition-colors" %>
+                        <% end %>
+                        <% if can_unassign %>
+                          <%= button_to "解除", unassign_room_key_path(room.id, user_id: key.user_id),
+                              method: :post,
+                              form: { class: "flex-1", onsubmit: "return confirm('#{j(key.user&.display_name.to_s)} の鍵の割り当てを解除しますか？')" },
+                              class: "w-full px-2.5 py-1.5 bg-red-500 text-white text-xs font-medium rounded-md text-center hover:bg-red-600 transition-colors" %>
+                        <% end %>
+                      </div>
                     <% end %>
                   </div>
                 <% end %>

--- a/app/views/keys/index.html.erb
+++ b/app/views/keys/index.html.erb
@@ -1,5 +1,5 @@
 <div class="space-y-6 px-4 py-6 md:px-8">
-  <h1 class="text-2xl font-bold text-gray-800">鍵管理</h1>
+  <h1 class="text-2xl font-bold text-gray-800">🔑 鍵管理</h1>
 
   <!-- Flash Messages -->
   <% if flash[:notice] %>

--- a/app/views/keys/transfer_form.html.erb
+++ b/app/views/keys/transfer_form.html.erb
@@ -1,6 +1,6 @@
 <div class="space-y-6 px-4 py-6 md:px-8">
   <div class="flex items-center justify-between">
-    <h1 class="text-2xl font-bold text-gray-800">鍵の譲渡</h1>
+    <h1 class="text-2xl font-bold text-gray-800">🔑 鍵の譲渡</h1>
     <%= link_to "戻る", keys_path, class: "text-sm text-primary hover:text-primary-dark font-medium" %>
   </div>
 

--- a/app/views/layouts/admin.html.erb
+++ b/app/views/layouts/admin.html.erb
@@ -1,5 +1,5 @@
 <div class="space-y-6 px-4 py-6 md:px-8">
-  <h1 class="text-2xl font-bold text-gray-800">管理画面</h1>
+  <h1 class="text-2xl font-bold text-gray-800">🛡️ 管理画面</h1>
 
   <%= render 'admin/nav' %>
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -88,7 +88,7 @@
             <% end %>
             <%= link_to nfc_cards_path, class: "w-full flex items-center gap-3 px-4 py-3 text-gray-700 hover:bg-gray-50 #{current_user&.admin? ? '' : 'rounded-t-lg'} transition-colors" do %>
               <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.5 1.5H8.25A2.25 2.25 0 006 3.75v16.5a2.25 2.25 0 002.25 2.25h7.5A2.25 2.25 0 0018 20.25V3.75a2.25 2.25 0 00-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3m-3 18.75h3"></path>
+                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.25 7.5A2.25 2.25 0 014.5 5.25h15A2.25 2.25 0 0121.75 7.5v9A2.25 2.25 0 0119.5 18.75h-15A2.25 2.25 0 012.25 16.5v-9zm0 3h19.5m-13.5 4.5h3"></path>
               </svg>
               <span class="text-sm font-medium">NFCカード</span>
               <% if current_user && !current_user.nfc_card %>
@@ -139,7 +139,7 @@
           <% end %>
           <%= link_to nfc_cards_path, class: "w-full flex items-center gap-3 px-4 py-3 text-gray-700 hover:bg-gray-50 transition-colors" do %>
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.5 1.5H8.25A2.25 2.25 0 006 3.75v16.5a2.25 2.25 0 002.25 2.25h7.5A2.25 2.25 0 0018 20.25V3.75a2.25 2.25 0 00-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3m-3 18.75h3"></path>
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.25 7.5A2.25 2.25 0 014.5 5.25h15A2.25 2.25 0 0121.75 7.5v9A2.25 2.25 0 0119.5 18.75h-15A2.25 2.25 0 012.25 16.5v-9zm0 3h19.5m-13.5 4.5h3"></path>
             </svg>
             <span class="text-sm font-medium">NFCカード</span>
             <% if current_user && !current_user.nfc_card %>

--- a/app/views/nfc_cards/index.html.erb
+++ b/app/views/nfc_cards/index.html.erb
@@ -1,5 +1,5 @@
 <div class="space-y-6 px-4 py-6 md:px-8">
-  <h1 class="text-2xl font-bold text-gray-800">NFCカード管理</h1>
+  <h1 class="text-2xl font-bold text-gray-800">🪪 NFCカード管理</h1>
 
   <!-- Flash Messages -->
   <% if flash[:notice] %>

--- a/app/views/nfc_cards/index.html.erb
+++ b/app/views/nfc_cards/index.html.erb
@@ -21,7 +21,7 @@
       <div class="flex items-start justify-between mb-4">
         <div class="flex items-center gap-2">
           <svg class="w-5 h-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.5 1.5H8.25A2.25 2.25 0 006 3.75v16.5a2.25 2.25 0 002.25 2.25h7.5A2.25 2.25 0 0018 20.25V3.75a2.25 2.25 0 00-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3m-3 18.75h3"></path>
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.25 7.5A2.25 2.25 0 014.5 5.25h15A2.25 2.25 0 0121.75 7.5v9A2.25 2.25 0 0119.5 18.75h-15A2.25 2.25 0 012.25 16.5v-9zm0 3h19.5m-13.5 4.5h3"></path>
           </svg>
           <span class="text-xs font-medium text-gray-500">NFC Card</span>
         </div>
@@ -83,7 +83,7 @@
       <div class="bg-gray-50 border border-gray-200 rounded-xl p-5 mb-4">
         <div class="flex items-center gap-2 mb-3">
           <svg class="w-5 h-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M10.5 1.5H8.25A2.25 2.25 0 006 3.75v16.5a2.25 2.25 0 002.25 2.25h7.5A2.25 2.25 0 0018 20.25V3.75a2.25 2.25 0 00-2.25-2.25H13.5m-3 0V3h3V1.5m-3 0h3m-3 18.75h3"></path>
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.25 7.5A2.25 2.25 0 014.5 5.25h15A2.25 2.25 0 0121.75 7.5v9A2.25 2.25 0 0119.5 18.75h-15A2.25 2.25 0 012.25 16.5v-9zm0 3h19.5m-13.5 4.5h3"></path>
           </svg>
           <span class="text-xs font-medium text-gray-500">NFC Card</span>
         </div>

--- a/app/views/reservations/edit.html.erb
+++ b/app/views/reservations/edit.html.erb
@@ -3,7 +3,7 @@
     <%= link_to reservations_path(start_date: @reservation.reservation_date&.beginning_of_month), class: "text-gray-500 hover:text-gray-700 mr-4" do %>
       <%= render Icons::ArrowLeftComponent.new(classes: "w-6 h-6") %>
     <% end %>
-    <h1 class="text-2xl font-bold text-gray-800">予約の編集</h1>
+    <h1 class="text-2xl font-bold text-gray-800">📅 予約の編集</h1>
   </div>
 
   <!-- Existing Reservations Section -->

--- a/app/views/reservations/edit.html.erb
+++ b/app/views/reservations/edit.html.erb
@@ -3,7 +3,7 @@
     <%= link_to reservations_path(start_date: @reservation.reservation_date&.beginning_of_month), class: "text-gray-500 hover:text-gray-700 mr-4" do %>
       <%= render Icons::ArrowLeftComponent.new(classes: "w-6 h-6") %>
     <% end %>
-    <h1 class="text-2xl font-bold text-gray-800">📅 予約の編集</h1>
+    <h1 class="text-2xl font-bold text-gray-800" aria-label="予約の編集">📅 予約の編集</h1>
   </div>
 
   <!-- Existing Reservations Section -->

--- a/app/views/reservations/index.html.erb
+++ b/app/views/reservations/index.html.erb
@@ -11,8 +11,10 @@
     </h2>
 
     <div class="flex flex-col items-end gap-2 shrink-0">
-      <%= link_to reservations_path(start_date: Date.current), class: "inline-flex items-center px-3 py-1.5 text-sm font-medium text-white bg-primary rounded-lg hover:bg-primary-dark transition-colors whitespace-nowrap" do %>
-        今月に戻る
+      <% if @current_month.year != Date.current.year || @current_month.month != Date.current.month %>
+        <%= link_to reservations_path(start_date: Date.current), class: "inline-flex items-center px-3 py-1.5 text-sm font-medium text-white bg-primary rounded-lg hover:bg-primary-dark transition-colors whitespace-nowrap" do %>
+          今月に戻る
+        <% end %>
       <% end %>
 
       <div class="flex items-center gap-2">

--- a/app/views/reservations/index.html.erb
+++ b/app/views/reservations/index.html.erb
@@ -5,28 +5,31 @@
   </div>
 
   <!-- Header: Month Navigation -->
-  <div class="flex items-center justify-between mb-4">
-    <div class="flex items-center gap-4">
-      <h2 class="text-xl font-semibold text-gray-700">
-        <%= @current_month.year %>年 <%= @current_month.month %>月
-      </h2>
-      <div class="flex gap-1">
-        <%= link_to reservations_path(start_date: @current_month.prev_month), class: "p-1 hover:bg-gray-100 rounded-full transition-colors" do %>
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5 text-gray-600">
+  <div class="mb-4 flex items-end justify-between gap-3">
+    <h2 class="text-xl font-semibold text-gray-700 whitespace-nowrap">
+      <%= @current_month.year %>年 <%= @current_month.month %>月
+    </h2>
+
+    <div class="flex flex-col items-end gap-2 shrink-0">
+      <%= link_to reservations_path(start_date: Date.current), class: "inline-flex items-center px-3 py-1.5 text-sm font-medium text-white bg-primary rounded-lg hover:bg-primary-dark transition-colors whitespace-nowrap" do %>
+        今月に戻る
+      <% end %>
+
+      <div class="flex items-center gap-2">
+        <%= link_to reservations_path(start_date: @current_month.prev_month), class: "inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-700 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors whitespace-nowrap" do %>
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-4 h-4 text-gray-600">
             <path stroke-linecap="round" stroke-linejoin="round" d="M15.75 19.5 8.25 12l7.5-7.5" />
           </svg>
+          <span>前の月</span>
         <% end %>
-        <%= link_to reservations_path(start_date: @current_month.next_month), class: "p-1 hover:bg-gray-100 rounded-full transition-colors" do %>
-          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5 text-gray-600">
+        <%= link_to reservations_path(start_date: @current_month.next_month), class: "inline-flex items-center gap-1.5 px-3 py-1.5 text-sm font-medium text-gray-700 bg-white border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors whitespace-nowrap" do %>
+          <span>次の月</span>
+          <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-4 h-4 text-gray-600">
             <path stroke-linecap="round" stroke-linejoin="round" d="m8.25 4.5 7.5 7.5-7.5 7.5" />
           </svg>
         <% end %>
       </div>
     </div>
-    
-    <%= link_to reservations_path(start_date: Date.current), class: "text-sm text-primary hover:text-primary-dark font-medium" do %>
-      今日に戻る
-    <% end %>
   </div>
 
   <!-- Validations Error Message (if redirected from failed create) -->

--- a/app/views/reservations/index.html.erb
+++ b/app/views/reservations/index.html.erb
@@ -1,10 +1,15 @@
 <div class="px-1 py-6 md:px-8 space-y-6">
+  <div class="px-4 md:px-0">
+    <h1 class="text-2xl font-bold text-gray-800">📅 部室予約</h1>
+    <p class="text-sm text-gray-600 mt-1">予約を作成/編集したい日付をタップ</p>
+  </div>
+
   <!-- Header: Month Navigation -->
   <div class="flex items-center justify-between mb-4">
     <div class="flex items-center gap-4">
-      <h1 class="text-2xl font-bold text-gray-800">
-        📅 <%= @current_month.year %>年 <%= @current_month.month %>月
-      </h1>
+      <h2 class="text-xl font-semibold text-gray-700">
+        <%= @current_month.year %>年 <%= @current_month.month %>月
+      </h2>
       <div class="flex gap-1">
         <%= link_to reservations_path(start_date: @current_month.prev_month), class: "p-1 hover:bg-gray-100 rounded-full transition-colors" do %>
           <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="2" stroke="currentColor" class="w-5 h-5 text-gray-600">

--- a/app/views/reservations/index.html.erb
+++ b/app/views/reservations/index.html.erb
@@ -3,7 +3,7 @@
   <div class="flex items-center justify-between mb-4">
     <div class="flex items-center gap-4">
       <h1 class="text-2xl font-bold text-gray-800">
-        <%= @current_month.year %>年 <%= @current_month.month %>月
+        📅 <%= @current_month.year %>年 <%= @current_month.month %>月
       </h1>
       <div class="flex gap-1">
         <%= link_to reservations_path(start_date: @current_month.prev_month), class: "p-1 hover:bg-gray-100 rounded-full transition-colors" do %>

--- a/app/views/reservations/new.html.erb
+++ b/app/views/reservations/new.html.erb
@@ -3,7 +3,7 @@
     <%= link_to reservations_path(start_date: @reservation.reservation_date&.beginning_of_month), class: "text-gray-500 hover:text-gray-700 mr-4" do %>
       <%= render Icons::ArrowLeftComponent.new(classes: "w-6 h-6") %>
     <% end %>
-    <h1 class="text-2xl font-bold text-gray-800">予約</h1>
+    <h1 class="text-2xl font-bold text-gray-800">📅 予約</h1>
   </div>
 
   <!-- Existing Reservations Section -->

--- a/app/views/room_statuses/index.html.erb
+++ b/app/views/room_statuses/index.html.erb
@@ -1,5 +1,5 @@
 <div class="space-y-6 px-4 py-6 md:px-8">
-  <h1 class="text-2xl font-bold text-gray-800">部室状況</h1>
+  <h1 class="text-2xl font-bold text-gray-800">🚪 部室状況</h1>
 
   <% if flash[:notice] %>
     <div class="bg-green-50 text-green-700 p-4 rounded-lg text-sm">

--- a/app/views/stats/me.html.erb
+++ b/app/views/stats/me.html.erb
@@ -1,8 +1,8 @@
 <div class="space-y-6 px-4 py-6 md:px-8">
   <div class="flex items-center justify-between">
-    <h1 class="text-2xl font-bold text-gray-800">利用統計</h1>
+    <h1 class="text-2xl font-bold text-gray-800">📊 利用統計</h1>
     <%= link_to stats_ranking_path, class: "btn btn-secondary text-sm" do %>
-      ランキングを見る
+      👑 ランキングを見る
     <% end %>
   </div>
 

--- a/app/views/stats/ranking.html.erb
+++ b/app/views/stats/ranking.html.erb
@@ -1,8 +1,8 @@
 <div class="space-y-6 px-4 py-6 md:px-8">
   <div class="flex items-center justify-between">
-    <h1 class="text-2xl font-bold text-gray-800">ランキング</h1>
+    <h1 class="text-2xl font-bold text-gray-800">👑 ランキング</h1>
     <%= link_to stats_me_path, class: "btn btn-secondary text-sm" do %>
-      自分の統計を見る
+      📊 自分の統計を見る
     <% end %>
   </div>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * ページヘッダーに絵文字プレフィックスを追加（🚪、📅、🔑、🛡️、🪪、📊、👑）
  * ナビゲーションのSVGアイコンパスを更新
  * 鍵管理ページを単一リスト/縦積み表示に再構成、月ナビゲーションのレイアウト調整
  * 予約リストのアイテム装飾を簡素化（左ボーダー削除）

* **UX**
  * モバイル向けアバター表示改善：極小サイズ（xxs）対応、境界線と影の調整でボーダレス/フラット表示を追加
  * 小画面での予約時刻表示を簡潔化
<!-- end of auto-generated comment: release notes by coderabbit.ai -->