### PR TITLE
訪問日数のバグ修正＋年度フィルターを廃止し、期間フィルターに変更

### DIFF
--- a/app/controllers/api/stats_controller.rb
+++ b/app/controllers/api/stats_controller.rb
@@ -4,8 +4,7 @@ module Api
   class StatsController < BaseController
     skip_before_action :authenticate_user!
     before_action :authenticate_api_key!
-
-    VALID_PERIODS = %w[today week month half_year year all].freeze
+    include PeriodFilterable
 
     # GET /api/stats/ranking
     def ranking
@@ -78,9 +77,9 @@ module Api
         }
       end
 
-      # デフォルト条件（訪問日数/今月/全部室）でのランキング順位
-      rank_range = period_date_range("month")
-      rank_scope = RoomVisit.where(entered_at: rank_range)
+      # ランキング順位（ユーザーが選択した期間と同じ範囲で算出）
+      rank_range = period_date_range(period)
+      rank_scope = rank_range ? RoomVisit.where(entered_at: rank_range) : RoomVisit.all
       all_visit_counts = rank_scope
         .group(:user_id)
         .select("user_id, COUNT(DISTINCT DATE(entered_at AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')) AS visit_count")
@@ -94,29 +93,11 @@ module Api
         period: period,
         total: { visit_days: total_visit_days, total_seconds: total_duration },
         rooms: per_room,
-        rank: { position: visit_rank, total_users: total_ranked_users, period: "month" }
+        rank: { position: visit_rank, total_users: total_ranked_users, period: period }
       }
     end
 
     private
-
-    def period_date_range(period)
-      now = Time.current.in_time_zone("Asia/Tokyo")
-      case period
-      when "today"
-        now.beginning_of_day..now
-      when "week"
-        now.beginning_of_week(:monday)..now
-      when "month"
-        now.beginning_of_month..now
-      when "half_year"
-        6.months.ago.in_time_zone("Asia/Tokyo").beginning_of_day..now
-      when "year"
-        1.year.ago.in_time_zone("Asia/Tokyo").beginning_of_day..now
-      when "all"
-        nil
-      end
-    end
 
     def visit_ranking(scope, _room)
       # 訪問回数: 1日1カウント（同日複数入室でも1）

--- a/app/controllers/api/stats_controller.rb
+++ b/app/controllers/api/stats_controller.rb
@@ -5,24 +5,24 @@ module Api
     skip_before_action :authenticate_user!
     before_action :authenticate_api_key!
 
+    VALID_PERIODS = %w[today week month half_year year all].freeze
+
     # GET /api/stats/ranking
     def ranking
       type = params[:type].presence || "visits"
-      year_param = params[:year].presence || current_fiscal_year.to_s
+      period = params[:period].presence || "month"
       room = params[:room].presence || "all"
 
       unless %w[visits duration].include?(type)
         return render json: { error: "Invalid type. Use 'visits' or 'duration'." }, status: :bad_request
       end
+      unless VALID_PERIODS.include?(period)
+        return render json: { error: "Invalid period. Use 'today', 'week', 'month', 'half_year', 'year', or 'all'." }, status: :bad_request
+      end
 
       base_scope = RoomVisit.all
-      year = parse_year_param(year_param)
-      return render json: { error: "Invalid year." }, status: :bad_request if year.nil?
-
-      if year != "all"
-        start_date, end_date = fiscal_year_range(year)
-        base_scope = base_scope.where(entered_at: start_date..end_date)
-      end
+      date_range = period_date_range(period)
+      base_scope = base_scope.where(entered_at: date_range) if date_range
       base_scope = base_scope.where(room_id: room) unless room == "all"
 
       ranking_data = if type == "visits"
@@ -33,7 +33,7 @@ module Api
 
       render json: {
         type: type,
-        year: year,
+        period: period,
         room: room,
         ranking: ranking_data
       }
@@ -44,16 +44,14 @@ module Api
       user = User.find_by(discord_id: params[:discord_user_id])
       return render json: { error: "User not found." }, status: :not_found unless user
 
-      year_param = params[:year].presence || current_fiscal_year.to_s
+      period = params[:period].presence || "month"
+      unless VALID_PERIODS.include?(period)
+        return render json: { error: "Invalid period. Use 'today', 'week', 'month', 'half_year', 'year', or 'all'." }, status: :bad_request
+      end
 
       base_scope = RoomVisit.where(user: user)
-      year = parse_year_param(year_param)
-      return render json: { error: "Invalid year." }, status: :bad_request if year.nil?
-
-      if year != "all"
-        start_date, end_date = fiscal_year_range(year)
-        base_scope = base_scope.where(entered_at: start_date..end_date)
-      end
+      date_range = period_date_range(period)
+      base_scope = base_scope.where(entered_at: date_range) if date_range
 
       # 全部室合算
       total_visit_days = base_scope
@@ -80,10 +78,9 @@ module Api
         }
       end
 
-      # デフォルト条件（訪問日数/今年度/全部室）でのランキング順位
-      fiscal_year = current_fiscal_year
-      rank_start, rank_end = fiscal_year_range(fiscal_year)
-      rank_scope = RoomVisit.where(entered_at: rank_start..rank_end)
+      # デフォルト条件（訪問日数/今月/全部室）でのランキング順位
+      rank_range = period_date_range("month")
+      rank_scope = RoomVisit.where(entered_at: rank_range)
       all_visit_counts = rank_scope
         .group(:user_id)
         .select("user_id, COUNT(DISTINCT DATE(entered_at AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')) AS visit_count")
@@ -94,31 +91,31 @@ module Api
 
       render json: {
         user: { id: user.id, display_name: user.display_name, discord_id: user.discord_id },
-        year: year,
+        period: period,
         total: { visit_days: total_visit_days, total_seconds: total_duration },
         rooms: per_room,
-        rank: { position: visit_rank, total_users: total_ranked_users, fiscal_year: fiscal_year }
+        rank: { position: visit_rank, total_users: total_ranked_users, period: "month" }
       }
     end
 
     private
 
-    def parse_year_param(year_param)
-      return "all" if year_param == "all"
-      return nil unless year_param.match?(/\A\d{4}\z/)
-
-      year_param.to_i
-    end
-
-    def current_fiscal_year
-      today = Time.current.in_time_zone("Asia/Tokyo").to_date
-      today.month >= 4 ? today.year : today.year - 1
-    end
-
-    def fiscal_year_range(year)
-      start_date = Time.zone.parse("#{year}-04-01").in_time_zone("Asia/Tokyo").beginning_of_day
-      end_date = Time.zone.parse("#{year + 1}-03-31").in_time_zone("Asia/Tokyo").end_of_day
-      [ start_date, end_date ]
+    def period_date_range(period)
+      now = Time.current.in_time_zone("Asia/Tokyo")
+      case period
+      when "today"
+        now.beginning_of_day..now
+      when "week"
+        now.beginning_of_week(:monday)..now
+      when "month"
+        now.beginning_of_month..now
+      when "half_year"
+        6.months.ago.in_time_zone("Asia/Tokyo").beginning_of_day..now
+      when "year"
+        1.year.ago.in_time_zone("Asia/Tokyo").beginning_of_day..now
+      when "all"
+        nil
+      end
     end
 
     def visit_ranking(scope, _room)

--- a/app/controllers/api/stats_controller.rb
+++ b/app/controllers/api/stats_controller.rb
@@ -57,7 +57,7 @@ module Api
 
       # 全部室合算
       total_visit_days = base_scope
-        .count("DISTINCT DATE(entered_at AT TIME ZONE 'Asia/Tokyo')")
+        .count("DISTINCT DATE(entered_at AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')")
       total_duration = base_scope
         .where.not(exited_at: nil)
         .sum("EXTRACT(EPOCH FROM (exited_at - entered_at))").to_i
@@ -67,7 +67,7 @@ module Api
       per_room = rooms.map do |room|
         room_scope = base_scope.where(room: room)
         visit_days = room_scope
-          .count("DISTINCT DATE(entered_at AT TIME ZONE 'Asia/Tokyo')")
+          .count("DISTINCT DATE(entered_at AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')")
         duration = room_scope
           .where.not(exited_at: nil)
           .sum("EXTRACT(EPOCH FROM (exited_at - entered_at))").to_i
@@ -86,7 +86,7 @@ module Api
       rank_scope = RoomVisit.where(entered_at: rank_start..rank_end)
       all_visit_counts = rank_scope
         .group(:user_id)
-        .select("user_id, COUNT(DISTINCT DATE(entered_at AT TIME ZONE 'Asia/Tokyo')) AS visit_count")
+        .select("user_id, COUNT(DISTINCT DATE(entered_at AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')) AS visit_count")
         .order("visit_count DESC, user_id ASC")
       rank_position = all_visit_counts.each_with_index.find { |r, _| r.user_id == user.id }&.last
       visit_rank = rank_position ? rank_position + 1 : nil
@@ -125,7 +125,7 @@ module Api
       # 訪問回数: 1日1カウント（同日複数入室でも1）
       # room=all の場合は部室横断で日付DISTINCT、部室指定時はscopeで既に絞り込み済み
       results = scope
-        .select("user_id, COUNT(DISTINCT DATE(entered_at AT TIME ZONE 'Asia/Tokyo')) AS visit_count")
+        .select("user_id, COUNT(DISTINCT DATE(entered_at AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')) AS visit_count")
         .group(:user_id)
         .order("visit_count DESC")
         .limit(10)

--- a/app/controllers/api/stats_controller.rb
+++ b/app/controllers/api/stats_controller.rb
@@ -9,7 +9,7 @@ module Api
     # GET /api/stats/ranking
     def ranking
       type = params[:type].presence || "visits"
-      period = params[:period].presence || "month"
+      period = params[:period].presence || "all"
       room = params[:room].presence || "all"
 
       unless %w[visits duration].include?(type)
@@ -43,7 +43,7 @@ module Api
       user = User.find_by(discord_id: params[:discord_user_id])
       return render json: { error: "User not found." }, status: :not_found unless user
 
-      period = params[:period].presence || "month"
+      period = params[:period].presence || "all"
       unless VALID_PERIODS.include?(period)
         return render json: { error: "Invalid period. Use 'today', 'week', 'month', 'half_year', 'year', or 'all'." }, status: :bad_request
       end

--- a/app/controllers/concerns/period_filterable.rb
+++ b/app/controllers/concerns/period_filterable.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module PeriodFilterable
+  extend ActiveSupport::Concern
+
+  VALID_PERIODS = %w[today week month half_year year all].freeze
+
+  private
+
+  def period_date_range(period)
+    now = Time.current.in_time_zone("Asia/Tokyo")
+    case period
+    when "today"
+      now.beginning_of_day..now
+    when "week"
+      now.beginning_of_week(:monday)..now
+    when "month"
+      now.beginning_of_month..now
+    when "half_year"
+      6.months.ago.in_time_zone("Asia/Tokyo").beginning_of_day..now
+    when "year"
+      1.year.ago.in_time_zone("Asia/Tokyo").beginning_of_day..now
+    when "all"
+      nil
+    end
+  end
+end

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -39,7 +39,7 @@ class StatsController < ApplicationController
     end
 
     @total_visit_days = base_scope
-      .count("DISTINCT DATE(entered_at AT TIME ZONE 'Asia/Tokyo')")
+      .count("DISTINCT DATE(entered_at AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')")
     @total_duration = base_scope
       .where.not(exited_at: nil)
       .sum("EXTRACT(EPOCH FROM (exited_at - entered_at))").to_i
@@ -48,7 +48,7 @@ class StatsController < ApplicationController
 
     visit_by_room = base_scope
       .group(:room_id)
-      .count("DISTINCT DATE(entered_at AT TIME ZONE 'Asia/Tokyo')")
+      .count("DISTINCT DATE(entered_at AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')")
 
     duration_by_room = base_scope
       .where.not(exited_at: nil)
@@ -86,7 +86,7 @@ class StatsController < ApplicationController
 
   def visit_ranking(scope)
     results = scope
-      .select("user_id, COUNT(DISTINCT DATE(entered_at AT TIME ZONE 'Asia/Tokyo')) AS visit_count")
+      .select("user_id, COUNT(DISTINCT DATE(entered_at AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')) AS visit_count")
       .group(:user_id)
       .order("visit_count DESC")
 

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -1,9 +1,11 @@
 # frozen_string_literal: true
 
 class StatsController < ApplicationController
+  include PeriodFilterable
+
   # GET /stats/ranking
   def ranking
-    @period = params[:period].presence || "month"
+    @period = valid_period(params[:period])
     @type = params[:type].presence || "visits"
     @room_param = params[:room].presence || "all"
 
@@ -26,7 +28,7 @@ class StatsController < ApplicationController
 
   # GET /stats/me
   def me
-    @period = params[:period].presence || "month"
+    @period = valid_period(params[:period])
 
     base_scope = RoomVisit.where(user: current_user)
     date_range = period_date_range(@period)
@@ -60,22 +62,9 @@ class StatsController < ApplicationController
 
   private
 
-  def period_date_range(period)
-    now = Time.current.in_time_zone("Asia/Tokyo")
-    case period
-    when "today"
-      now.beginning_of_day..now
-    when "week"
-      now.beginning_of_week(:monday)..now
-    when "month"
-      now.beginning_of_month..now
-    when "half_year"
-      6.months.ago.in_time_zone("Asia/Tokyo").beginning_of_day..now
-    when "year"
-      1.year.ago.in_time_zone("Asia/Tokyo").beginning_of_day..now
-    when "all"
-      nil
-    end
+  def valid_period(param)
+    value = param.presence
+    VALID_PERIODS.include?(value) ? value : "month"
   end
 
   def visit_ranking(scope)

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -64,7 +64,7 @@ class StatsController < ApplicationController
 
   def valid_period(param)
     value = param.presence
-    VALID_PERIODS.include?(value) ? value : "month"
+    VALID_PERIODS.include?(value) ? value : "all"
   end
 
   def visit_ranking(scope)

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -3,18 +3,15 @@
 class StatsController < ApplicationController
   # GET /stats/ranking
   def ranking
-    @year_param = params[:year].presence || current_fiscal_year.to_s
+    @period = params[:period].presence || "month"
     @type = params[:type].presence || "visits"
     @room_param = params[:room].presence || "all"
 
-    @year = parse_year_param(@year_param)
     @rooms = Room.order(:id)
 
     base_scope = RoomVisit.all
-    if @year != "all"
-      start_date, end_date = fiscal_year_range(@year)
-      base_scope = base_scope.where(entered_at: start_date..end_date)
-    end
+    date_range = period_date_range(@period)
+    base_scope = base_scope.where(entered_at: date_range) if date_range
     unless @room_param == "all"
       parsed_room = @rooms.find { |r| r.id.to_s == @room_param }
       base_scope = base_scope.where(room_id: parsed_room.id) if parsed_room
@@ -29,14 +26,11 @@ class StatsController < ApplicationController
 
   # GET /stats/me
   def me
-    @year_param = params[:year].presence || current_fiscal_year.to_s
-    @year = parse_year_param(@year_param)
+    @period = params[:period].presence || "month"
 
     base_scope = RoomVisit.where(user: current_user)
-    if @year != "all"
-      start_date, end_date = fiscal_year_range(@year)
-      base_scope = base_scope.where(entered_at: start_date..end_date)
-    end
+    date_range = period_date_range(@period)
+    base_scope = base_scope.where(entered_at: date_range) if date_range
 
     @total_visit_days = base_scope
       .count("DISTINCT DATE(entered_at AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')")
@@ -66,22 +60,22 @@ class StatsController < ApplicationController
 
   private
 
-  def current_fiscal_year
-    today = Time.current.in_time_zone("Asia/Tokyo").to_date
-    today.month >= 4 ? today.year : today.year - 1
-  end
-
-  def parse_year_param(year_param)
-    return "all" if year_param == "all"
-    return current_fiscal_year unless year_param.match?(/\A\d{4}\z/)
-
-    year_param.to_i
-  end
-
-  def fiscal_year_range(year)
-    start_date = Time.zone.parse("#{year}-04-01").in_time_zone("Asia/Tokyo").beginning_of_day
-    end_date = Time.zone.parse("#{year + 1}-03-31").in_time_zone("Asia/Tokyo").end_of_day
-    [ start_date, end_date ]
+  def period_date_range(period)
+    now = Time.current.in_time_zone("Asia/Tokyo")
+    case period
+    when "today"
+      now.beginning_of_day..now
+    when "week"
+      now.beginning_of_week(:monday)..now
+    when "month"
+      now.beginning_of_month..now
+    when "half_year"
+      6.months.ago.in_time_zone("Asia/Tokyo").beginning_of_day..now
+    when "year"
+      1.year.ago.in_time_zone("Asia/Tokyo").beginning_of_day..now
+    when "all"
+      nil
+    end
   end
 
   def visit_ranking(scope)

--- a/app/helpers/stats_helper.rb
+++ b/app/helpers/stats_helper.rb
@@ -25,14 +25,17 @@ module StatsHelper
     safe_join(parts)
   end
 
-  def year_label(year)
-    year == "all" ? "全期間" : "#{year}年度"
-  end
+  PERIOD_OPTIONS = [
+    { value: "today", label: "今日" },
+    { value: "week", label: "今週" },
+    { value: "month", label: "今月" },
+    { value: "half_year", label: "半年間" },
+    { value: "year", label: "1年間" },
+    { value: "all", label: "全期間" }
+  ].freeze
 
-  def available_fiscal_years(first_year = 2025)
-    today = Time.current.in_time_zone("Asia/Tokyo").to_date
-    current = today.month >= 4 ? today.year : today.year - 1
-    (first_year..current).to_a
+  def period_label(period)
+    PERIOD_OPTIONS.find { |o| o[:value] == period }&.dig(:label) || "全期間"
   end
 
   def rank_medal(index)

--- a/app/helpers/stats_helper.rb
+++ b/app/helpers/stats_helper.rb
@@ -38,6 +38,12 @@ module StatsHelper
     PERIOD_OPTIONS.find { |o| o[:value] == period }&.dig(:label) || "全期間"
   end
 
+  def room_label(room_param, rooms)
+    return "全部室" if room_param == "all"
+
+    rooms.find { |r| r.id.to_s == room_param }&.name || "全部室"
+  end
+
   def rank_medal(index)
     case index
     when 0 then "🥇"

--- a/app/views/stats/me.html.erb
+++ b/app/views/stats/me.html.erb
@@ -6,15 +6,14 @@
     <% end %>
   </div>
 
-  <!-- 年度フィルター -->
+  <!-- 期間フィルター -->
   <%= form_with url: stats_me_path, method: :get, class: "card p-4", local: true do %>
     <div class="flex flex-wrap gap-3 items-end">
       <div>
-        <label class="block text-xs font-medium text-gray-600 mb-1">年度</label>
-        <select name="year" class="block w-full rounded-lg border-gray-300 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500">
-          <option value="all" <%= "selected" if @year_param == "all" %>>全期間</option>
-          <% available_fiscal_years.each do |y| %>
-            <option value="<%= y %>" <%= "selected" if @year_param == y.to_s %>><%= y %>年度</option>
+        <label class="block text-xs font-medium text-gray-600 mb-1">期間</label>
+        <select name="period" class="block w-full rounded-lg border-gray-300 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500">
+          <% StatsHelper::PERIOD_OPTIONS.each do |opt| %>
+            <option value="<%= opt[:value] %>" <%= "selected" if @period == opt[:value] %>><%= opt[:label] %></option>
           <% end %>
         </select>
       </div>
@@ -28,7 +27,7 @@
   <div class="card p-5">
     <h2 class="text-lg font-bold text-gray-800 mb-4">
       全体
-      <span class="text-sm font-normal text-gray-500">（<%= year_label(@year) %>）</span>
+      <span class="text-sm font-normal text-gray-500">（<%= period_label(@period) %>）</span>
     </h2>
     <div class="grid grid-cols-2 gap-4">
       <div class="bg-blue-50 rounded-xl p-4 text-center">

--- a/app/views/stats/ranking.html.erb
+++ b/app/views/stats/ranking.html.erb
@@ -17,11 +17,10 @@
         </select>
       </div>
       <div>
-        <label class="block text-xs font-medium text-gray-600 mb-1">年度</label>
-        <select name="year" class="block w-full rounded-lg border-gray-300 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500">
-          <option value="all" <%= "selected" if @year_param == "all" %>>全期間</option>
-          <% available_fiscal_years.each do |y| %>
-            <option value="<%= y %>" <%= "selected" if @year_param == y.to_s %>><%= y %>年度</option>
+        <label class="block text-xs font-medium text-gray-600 mb-1">期間</label>
+        <select name="period" class="block w-full rounded-lg border-gray-300 text-sm shadow-sm focus:border-blue-500 focus:ring-blue-500">
+          <% StatsHelper::PERIOD_OPTIONS.each do |opt| %>
+            <option value="<%= opt[:value] %>" <%= "selected" if @period == opt[:value] %>><%= opt[:label] %></option>
           <% end %>
         </select>
       </div>
@@ -47,7 +46,7 @@
         <%= @type == "visits" ? "訪問日数" : "滞在時間" %>ランキング
         <br class="md:hidden">
         <span class="text-sm font-normal text-gray-500 whitespace-nowrap">
-          （<%= year_label(@year) %> / <%= @room_param == "all" ? "全部室" : @rooms.find { |r| r.id.to_s == @room_param }&.name || "全部室" %>）
+          （<%= period_label(@period) %> / <%= @room_param == "all" ? "全部室" : @rooms.find { |r| r.id.to_s == @room_param }&.name || "全部室" %>）
         </span>
       </h2>
     </div>

--- a/app/views/stats/ranking.html.erb
+++ b/app/views/stats/ranking.html.erb
@@ -46,7 +46,7 @@
         <%= @type == "visits" ? "訪問日数" : "滞在時間" %>ランキング
         <br class="md:hidden">
         <span class="text-sm font-normal text-gray-500 whitespace-nowrap">
-          （<%= period_label(@period) %> / <%= @room_param == "all" ? "全部室" : @rooms.find { |r| r.id.to_s == @room_param }&.name || "全部室" %>）
+          （<%= period_label(@period) %> / <%= room_label(@room_param, @rooms) %>）
         </span>
       </h2>
     </div>

--- a/discord-bot/src/api.ts
+++ b/discord-bot/src/api.ts
@@ -90,12 +90,12 @@ export interface MyStatsRoom {
 export interface MyStatsRank {
 	position: number | null;
 	total_users: number;
-	fiscal_year: number;
+	period: string;
 }
 
 export interface MyStatsResponse {
 	user: { id: number; display_name: string; discord_id?: string };
-	year: string;
+	period: string;
 	total: { visit_days: number; total_seconds: number };
 	rooms: MyStatsRoom[];
 	rank: MyStatsRank;
@@ -111,7 +111,7 @@ export interface RankingEntry {
 
 export interface RankingResponse {
 	type: string;
-	year: string;
+	period: string;
 	room: string;
 	ranking: RankingEntry[];
 }
@@ -213,20 +213,20 @@ function createApi(env: ApiEnv) {
 			return data.users.find(u => u.discord_id === discordUserId) ?? null;
 		},
 
-		async fetchMyStats(discordUserId: string, year?: string): Promise<MyStatsResponse> {
+		async fetchMyStats(discordUserId: string, period?: string): Promise<MyStatsResponse> {
 			const url = new URL(`${baseUrl}/stats/me`);
 			url.searchParams.append('discord_user_id', discordUserId);
-			if (year) url.searchParams.append('year', year);
+			if (period) url.searchParams.append('period', period);
 
 			const response = await fetchWithTimeout(url.toString());
 			if (!response.ok) await handleErrorResponse(response);
 			return await response.json() as MyStatsResponse;
 		},
 
-		async fetchRanking(type?: string, year?: string, room?: string): Promise<RankingResponse> {
+		async fetchRanking(type?: string, period?: string, room?: string): Promise<RankingResponse> {
 			const url = new URL(`${baseUrl}/stats/ranking`);
 			if (type) url.searchParams.append('type', type);
-			if (year) url.searchParams.append('year', year);
+			if (period) url.searchParams.append('period', period);
 			if (room) url.searchParams.append('room', room);
 
 			const response = await fetchWithTimeout(url.toString());

--- a/discord-bot/src/commands/me.ts
+++ b/discord-bot/src/commands/me.ts
@@ -24,7 +24,7 @@ export const meCommand = {
             return reply('ユーザー情報を取得できませんでした。');
         }
 
-        const period = getStringOption(interaction, 'period') ?? 'month';
+        const period = getStringOption(interaction, 'period') ?? 'all';
 
         try {
             const api = createApi(env);

--- a/discord-bot/src/commands/me.ts
+++ b/discord-bot/src/commands/me.ts
@@ -2,14 +2,14 @@ import { createApi } from '../api.js';
 import type { Interaction, CommandEnv } from './types.js';
 import { getStringOption, getUserId, reply, replyEmbed } from './utils.js';
 
-const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
-
-function currentFiscalYear(): number {
-    const jst = new Date(Date.now() + JST_OFFSET_MS);
-    const month = jst.getUTCMonth() + 1;
-    const year = jst.getUTCFullYear();
-    return month >= 4 ? year : year - 1;
-}
+const PERIOD_LABELS: Record<string, string> = {
+    today: '今日',
+    week: '今週',
+    month: '今月',
+    half_year: '半年間',
+    year: '1年間',
+    all: '全期間',
+};
 
 function formatDuration(totalSeconds: number): string {
     const hours = Math.floor(totalSeconds / 3600);
@@ -32,21 +32,20 @@ export const meCommand = {
             return reply('ユーザー情報を取得できませんでした。');
         }
 
-        const yearOption = getStringOption(interaction, 'year');
-        const year = yearOption ?? currentFiscalYear().toString();
+        const period = getStringOption(interaction, 'period') ?? 'month';
 
         try {
             const api = createApi(env);
-            const data = await api.fetchMyStats(discordUserId, year);
+            const data = await api.fetchMyStats(discordUserId, period);
 
-            const yearLabel = year === 'all' ? '全期間' : `${year}年度`;
-            const title = `📊 ${data.user.display_name} の部室利用統計（${yearLabel}）`;
+            const periodLabel = PERIOD_LABELS[period] ?? period;
+            const title = `📊 ${data.user.display_name} の部室利用統計（${periodLabel}）`;
 
             const lines: string[] = [];
 
             // ランキング順位
             if (data.rank.position !== null) {
-                lines.push(`🏅 訪問日数ランキング: **${data.rank.position}位** / ${data.rank.total_users}人中（${data.rank.fiscal_year}年度）`);
+                lines.push(`🏅 訪問日数ランキング: **${data.rank.position}位** / ${data.rank.total_users}人中（${PERIOD_LABELS[data.rank.period] ?? data.rank.period}）`);
                 lines.push('');
             }
 

--- a/discord-bot/src/commands/me.ts
+++ b/discord-bot/src/commands/me.ts
@@ -1,15 +1,7 @@
 import { createApi } from '../api.js';
+import { PERIOD_LABELS } from '../constants.js';
 import type { Interaction, CommandEnv } from './types.js';
 import { getStringOption, getUserId, reply, replyEmbed } from './utils.js';
-
-const PERIOD_LABELS: Record<string, string> = {
-    today: '今日',
-    week: '今週',
-    month: '今月',
-    half_year: '半年間',
-    year: '1年間',
-    all: '全期間',
-};
 
 function formatDuration(totalSeconds: number): string {
     const hours = Math.floor(totalSeconds / 3600);

--- a/discord-bot/src/commands/rank.ts
+++ b/discord-bot/src/commands/rank.ts
@@ -1,16 +1,8 @@
 import { createApi } from '../api.js';
 import type { RankingEntry } from '../api.js';
+import { PERIOD_LABELS } from '../constants.js';
 import type { Interaction, CommandEnv } from './types.js';
 import { getStringOption, reply, replyEmbed } from './utils.js';
-
-const PERIOD_LABELS: Record<string, string> = {
-    today: '今日',
-    week: '今週',
-    month: '今月',
-    half_year: '半年間',
-    year: '1年間',
-    all: '全期間',
-};
 
 function formatDuration(totalSeconds: number): string {
     const hours = Math.floor(totalSeconds / 3600);

--- a/discord-bot/src/commands/rank.ts
+++ b/discord-bot/src/commands/rank.ts
@@ -28,7 +28,7 @@ export const rankCommand = {
 
     async execute(interaction: Interaction, env: CommandEnv): Promise<object> {
         const type = getStringOption(interaction, 'type') ?? 'visits';
-        const period = getStringOption(interaction, 'period') ?? 'month';
+        const period = getStringOption(interaction, 'period') ?? 'all';
         const room = getStringOption(interaction, 'room');
 
         try {

--- a/discord-bot/src/commands/rank.ts
+++ b/discord-bot/src/commands/rank.ts
@@ -3,14 +3,14 @@ import type { RankingEntry } from '../api.js';
 import type { Interaction, CommandEnv } from './types.js';
 import { getStringOption, reply, replyEmbed } from './utils.js';
 
-const JST_OFFSET_MS = 9 * 60 * 60 * 1000;
-
-function currentFiscalYear(): number {
-    const jst = new Date(Date.now() + JST_OFFSET_MS);
-    const month = jst.getUTCMonth() + 1; // 1-indexed
-    const year = jst.getUTCFullYear();
-    return month >= 4 ? year : year - 1;
-}
+const PERIOD_LABELS: Record<string, string> = {
+    today: '今日',
+    week: '今週',
+    month: '今月',
+    half_year: '半年間',
+    year: '1年間',
+    all: '全期間',
+};
 
 function formatDuration(totalSeconds: number): string {
     const hours = Math.floor(totalSeconds / 3600);
@@ -36,14 +36,12 @@ export const rankCommand = {
 
     async execute(interaction: Interaction, env: CommandEnv): Promise<object> {
         const type = getStringOption(interaction, 'type') ?? 'visits';
-        const yearOption = getStringOption(interaction, 'year');
+        const period = getStringOption(interaction, 'period') ?? 'month';
         const room = getStringOption(interaction, 'room');
-
-        const year = yearOption ?? currentFiscalYear().toString();
 
         try {
             const api = createApi(env);
-            const data = await api.fetchRanking(type, year, room ?? 'all');
+            const data = await api.fetchRanking(type, period, room ?? 'all');
 
             if (data.ranking.length === 0) {
                 return reply('該当期間のデータがありません。');
@@ -51,8 +49,8 @@ export const rankCommand = {
 
             const typeLabel = type === 'visits' ? '訪問日数' : '滞在時間';
             const roomLabel = room ? `🚪第${room}部室` : '🚪全部室';
-            const yearLabel = year === 'all' ? '全期間' : `${year}年度`;
-            const title = `📊 ${typeLabel}ランキング（${yearLabel} / ${roomLabel}）`;
+            const periodLabel = PERIOD_LABELS[period] ?? period;
+            const title = `📊 ${typeLabel}ランキング（${periodLabel} / ${roomLabel}）`;
 
             const lines = data.ranking.map((entry: RankingEntry, i: number) => {
                 const name = entry.display_name ?? '不明なユーザー';

--- a/discord-bot/src/constants.ts
+++ b/discord-bot/src/constants.ts
@@ -1,0 +1,8 @@
+export const PERIOD_LABELS: Record<string, string> = {
+    today: '今日',
+    week: '今週',
+    month: '今月',
+    half_year: '半年間',
+    year: '1年間',
+    all: '全期間',
+};

--- a/discord-bot/src/deploy-commands.ts
+++ b/discord-bot/src/deploy-commands.ts
@@ -100,7 +100,15 @@ const commandDefinitions = [
                 )
         )
         .addStringOption(option =>
-            option.setName('year').setDescription('年度（例: 2025, 2026, all）').setRequired(false)
+            option.setName('period').setDescription('期間').setRequired(false)
+                .addChoices(
+                    { name: '今日', value: 'today' },
+                    { name: '今週', value: 'week' },
+                    { name: '今月', value: 'month' },
+                    { name: '半年間', value: 'half_year' },
+                    { name: '1年間', value: 'year' },
+                    { name: '全期間', value: 'all' }
+                )
         )
         .addStringOption(option =>
             option.setName('room').setDescription('部室番号（省略時は全部室を表示）').setRequired(false)
@@ -115,7 +123,15 @@ const commandDefinitions = [
         .setName('me')
         .setDescription('自分の部室利用統計を表示します')
         .addStringOption(option =>
-            option.setName('year').setDescription('年度（例: 2025, 2026, all）').setRequired(false)
+            option.setName('period').setDescription('期間').setRequired(false)
+                .addChoices(
+                    { name: '今日', value: 'today' },
+                    { name: '今週', value: 'week' },
+                    { name: '今月', value: 'month' },
+                    { name: '半年間', value: 'half_year' },
+                    { name: '1年間', value: 'year' },
+                    { name: '全期間', value: 'all' }
+                )
         ),
 ];
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 統計情報のフィルタリングが「年度」から「期間」ベースに変更されました
  * 今日、今週、今月、6ヶ月前、1年前、全期間から選択可能な6つの期間オプションが追加されました
  * Discord ボットのコマンドで期間オプションが統一され、デフォルトは「今月」に設定されました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->