### PR TITLE
学生証Onlyに変更＋通知チャンネル修正＋ランキングの同順修正

### DIFF
--- a/app/controllers/api/nfc_registrations_controller.rb
+++ b/app/controllers/api/nfc_registrations_controller.rb
@@ -41,6 +41,10 @@ module Api
         return render json: { error: "カードがまだ読み取られていません" }, status: :unprocessable_entity
       end
 
+      if @registration.student_id.blank? || @registration.student_name.blank?
+        return render json: { error: "学生証以外のカードは登録できません。学生証をかざしてください。" }, status: :unprocessable_entity
+      end
+
       # 既に登録済みのカードでないか確認
       if NfcCard.exists?(card_uid: @registration.card_uid)
         return render json: { error: "このカードは既に登録されています" }, status: :unprocessable_entity

--- a/app/controllers/api/nfc_registrations_controller.rb
+++ b/app/controllers/api/nfc_registrations_controller.rb
@@ -64,7 +64,7 @@ module Api
       end
 
       @registration.destroy!
-      render json: { message: "NFCカードを登録しました" }, status: :ok
+      render json: { message: "学生証を登録しました" }, status: :ok
     end
 
     # DELETE /api/nfc_registrations/:id

--- a/app/controllers/api/nfc_registrations_controller.rb
+++ b/app/controllers/api/nfc_registrations_controller.rb
@@ -42,7 +42,7 @@ module Api
       end
 
       if @registration.student_id.blank? || @registration.student_name.blank?
-        return render json: { error: "学生証以外のカードは登録できません。学生証をかざしてください。" }, status: :unprocessable_entity
+        return render json: { error: "学生証の情報を読み取れませんでした。長めにかざしてみてください。" }, status: :unprocessable_entity
       end
 
       # 既に登録済みのカードでないか確認

--- a/app/controllers/api/stats_controller.rb
+++ b/app/controllers/api/stats_controller.rb
@@ -110,7 +110,7 @@ module Api
 
       users = User.where(id: results.map(&:user_id)).index_by(&:id)
 
-      results.map do |r|
+      entries = results.map do |r|
         user = users[r.user_id]
         {
           user_id: r.user_id,
@@ -119,6 +119,7 @@ module Api
           count: r.visit_count.to_i
         }
       end
+      assign_ranks(entries) { |e| e[:count] }
     end
 
     def duration_ranking(scope)
@@ -132,7 +133,7 @@ module Api
 
       users = User.where(id: results.map(&:user_id)).index_by(&:id)
 
-      results.map do |r|
+      entries = results.map do |r|
         user = users[r.user_id]
         {
           user_id: r.user_id,
@@ -141,6 +142,19 @@ module Api
           total_seconds: r.total_seconds.to_i
         }
       end
+      assign_ranks(entries) { |e| e[:total_seconds] }
+    end
+
+    def assign_ranks(entries)
+      rank = 0
+      prev_value = nil
+      entries.each_with_index do |entry, i|
+        value = yield(entry)
+        rank = i + 1 if value != prev_value
+        entry[:rank] = rank
+        prev_value = value
+      end
+      entries
     end
   end
 end

--- a/app/controllers/api/stats_controller.rb
+++ b/app/controllers/api/stats_controller.rb
@@ -84,9 +84,21 @@ module Api
         .group(:user_id)
         .select("user_id, COUNT(DISTINCT DATE(entered_at AT TIME ZONE 'UTC' AT TIME ZONE 'Asia/Tokyo')) AS visit_count")
         .order("visit_count DESC, user_id ASC")
-      rank_position = all_visit_counts.each_with_index.find { |r, _| r.user_id == user.id }&.last
-      visit_rank = rank_position ? rank_position + 1 : nil
       total_ranked_users = all_visit_counts.length
+
+      # 同順位を考慮した順位計算
+      visit_rank = nil
+      rank = 0
+      prev_value = nil
+      all_visit_counts.each_with_index do |r, i|
+        value = r.visit_count.to_i
+        rank = i + 1 if value != prev_value
+        if r.user_id == user.id
+          visit_rank = rank
+          break
+        end
+        prev_value = value
+      end
 
       render json: {
         user: { id: user.id, display_name: user.display_name, discord_id: user.discord_id },

--- a/app/controllers/api/stats_controller.rb
+++ b/app/controllers/api/stats_controller.rb
@@ -86,26 +86,27 @@ module Api
         .order("visit_count DESC, user_id ASC")
       total_ranked_users = all_visit_counts.length
 
-      # 同順位を考慮した順位計算
-      visit_rank = nil
-      rank = 0
-      prev_value = nil
-      all_visit_counts.each_with_index do |r, i|
-        value = r.visit_count.to_i
-        rank = i + 1 if value != prev_value
-        if r.user_id == user.id
-          visit_rank = rank
-          break
-        end
-        prev_value = value
-      end
+      visit_rank = find_user_rank(all_visit_counts, user.id) { |r| r.visit_count.to_i }
+
+      # 滞在時間ランキング順位
+      all_durations = rank_scope
+        .where.not(exited_at: nil)
+        .group(:user_id)
+        .select("user_id, SUM(EXTRACT(EPOCH FROM (exited_at - entered_at))) AS total_seconds")
+        .order("total_seconds DESC, user_id ASC")
+
+      duration_rank = find_user_rank(all_durations, user.id) { |r| r.total_seconds.to_i }
 
       render json: {
         user: { id: user.id, display_name: user.display_name, discord_id: user.discord_id },
         period: period,
         total: { visit_days: total_visit_days, total_seconds: total_duration },
         rooms: per_room,
-        rank: { position: visit_rank, total_users: total_ranked_users, period: period }
+        rank: {
+          visit: { position: visit_rank, total_users: total_ranked_users },
+          duration: { position: duration_rank, total_users: all_durations.length },
+          period: period
+        }
       }
     end
 
@@ -155,6 +156,18 @@ module Api
         }
       end
       assign_ranks(entries) { |e| e[:total_seconds] }
+    end
+
+    def find_user_rank(results, user_id)
+      rank = 0
+      prev_value = nil
+      results.each_with_index do |r, i|
+        value = yield(r)
+        rank = i + 1 if value != prev_value
+        return rank if r.user_id == user_id
+        prev_value = value
+      end
+      nil
     end
 
     def assign_ranks(entries)

--- a/app/controllers/nfc_cards_controller.rb
+++ b/app/controllers/nfc_cards_controller.rb
@@ -18,7 +18,7 @@ class NfcCardsController < ApplicationController
     end
 
     card.destroy!
-    redirect_to nfc_cards_path, notice: "NFCカードを削除しました"
+    redirect_to nfc_cards_path, notice: "学生証を削除しました"
   rescue ActiveRecord::RecordNotFound
     redirect_to nfc_cards_path, alert: "カードが見つかりません"
   end

--- a/app/controllers/nfc_cards_controller.rb
+++ b/app/controllers/nfc_cards_controller.rb
@@ -20,6 +20,6 @@ class NfcCardsController < ApplicationController
     card.destroy!
     redirect_to nfc_cards_path, notice: "学生証を削除しました"
   rescue ActiveRecord::RecordNotFound
-    redirect_to nfc_cards_path, alert: "カードが見つかりません"
+    redirect_to nfc_cards_path, alert: "学生証が見つかりません"
   end
 end

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -74,7 +74,8 @@ class StatsController < ApplicationController
       .order("visit_count DESC")
 
     users = User.where(id: results.map(&:user_id)).index_by(&:id)
-    results.map { |r| { user: users[r.user_id], count: r.visit_count.to_i } }
+    entries = results.map { |r| { user: users[r.user_id], count: r.visit_count.to_i } }
+    assign_ranks(entries) { |e| e[:count] }
   end
 
   def duration_ranking(scope)
@@ -85,6 +86,19 @@ class StatsController < ApplicationController
       .order("total_seconds DESC")
 
     users = User.where(id: results.map(&:user_id)).index_by(&:id)
-    results.map { |r| { user: users[r.user_id], total_seconds: r.total_seconds.to_i } }
+    entries = results.map { |r| { user: users[r.user_id], total_seconds: r.total_seconds.to_i } }
+    assign_ranks(entries) { |e| e[:total_seconds] }
+  end
+
+  def assign_ranks(entries)
+    rank = 0
+    prev_value = nil
+    entries.each_with_index do |entry, i|
+      value = yield(entry)
+      rank = i + 1 if value != prev_value
+      entry[:rank] = rank
+      prev_value = value
+    end
+    entries
   end
 end

--- a/app/helpers/stats_helper.rb
+++ b/app/helpers/stats_helper.rb
@@ -44,12 +44,12 @@ module StatsHelper
     rooms.find { |r| r.id.to_s == room_param }&.name || "全部室"
   end
 
-  def rank_medal(index)
-    case index
-    when 0 then "🥇"
-    when 1 then "🥈"
-    when 2 then "🥉"
-    else "#{index + 1}"
+  def rank_medal(rank)
+    case rank
+    when 1 then "🥇"
+    when 2 then "🥈"
+    when 3 then "🥉"
+    else rank.to_s
     end
   end
 end

--- a/app/services/discord_notifier.rb
+++ b/app/services/discord_notifier.rb
@@ -25,6 +25,17 @@ class DiscordNotifier
     "room_closed" => { title: "🔒 部室が閉まりました", color: 0xff3333 }
   }.freeze
 
+  ROOM_EMOJIS = {
+    "第１部室" => "<:dai1:1225676713384607764>",
+    "第２部室" => "<:dai2:1225677193779216426>",
+    "第３部室" => "<:dai3:1363112241897017565>"
+  }.freeze
+
+  ACTION_EMOJIS = {
+    "room_opened" => "<:ake:1225676720493822003>",
+    "room_closed" => "<:shime:1225676717478252736>"
+  }.freeze
+
   def self.notify(type:, data:)
     return unless enabled?
 
@@ -186,21 +197,27 @@ class DiscordNotifier
   end
 
   def self.send_room_notification(type, data)
-    label = ROOM_LABELS[type] || { title: "🚪 部室通知", color: 0x0099ff }
-    room_name = "#{data[:room_name]}（#{data[:room_number]}）"
-    user = format_user_mention(data[:user_discord_id], data[:user_display_name])
-
     # 入退室は専用チャンネル、開閉は通常チャンネル
     target = %w[room_entered room_exited].include?(type) ? entry_channel_id : channel_id
 
-    post_message({
-      embeds: [ {
-        title: label[:title],
-        description: "🚪 #{room_name}\n#{user}",
-        color: label[:color],
-        timestamp: Time.current.iso8601
-      } ]
-    }, target_channel_id: target)
+    # 開閉通知はカスタム絵文字で送信
+    if %w[room_opened room_closed].include?(type)
+      room_emoji = ROOM_EMOJIS[data[:room_name]] || "🚪"
+      action_emoji = ACTION_EMOJIS[type] || ""
+      post_message({ content: "#{room_emoji} #{action_emoji}" }, target_channel_id: target)
+    else
+      label = ROOM_LABELS[type] || { title: "🚪 部室通知", color: 0x0099ff }
+      room_name = "#{data[:room_name]}（#{data[:room_number]}）"
+      user = format_user_mention(data[:user_discord_id], data[:user_display_name])
+      post_message({
+        embeds: [ {
+          title: label[:title],
+          description: "🚪 #{room_name}\n#{user}",
+          color: label[:color],
+          timestamp: Time.current.iso8601
+        } ]
+      }, target_channel_id: target)
+    end
   end
 
   private_class_method :post_message, :format_user_mention, :format_date_time,

--- a/app/services/discord_notifier.rb
+++ b/app/services/discord_notifier.rb
@@ -92,9 +92,13 @@ class DiscordNotifier
     ENV["ANNOUNCE_CHANNEL_ID"]
   end
 
+  def self.entry_channel_id
+    ENV.fetch("ENTRY_CHANNEL_ID", channel_id)
+  end
+
   # Discord APIにメッセージを送信する
-  def self.post_message(body)
-    uri = URI("#{DISCORD_API_BASE}/channels/#{channel_id}/messages")
+  def self.post_message(body, target_channel_id: channel_id)
+    uri = URI("#{DISCORD_API_BASE}/channels/#{target_channel_id}/messages")
     request = Net::HTTP::Post.new(uri.request_uri)
     request["Content-Type"] = "application/json"
     request["Authorization"] = "Bot #{bot_token}"
@@ -186,6 +190,9 @@ class DiscordNotifier
     room_name = "#{data[:room_name]}（#{data[:room_number]}）"
     user = format_user_mention(data[:user_discord_id], data[:user_display_name])
 
+    # 入退室は専用チャンネル、開閉は通常チャンネル
+    target = %w[room_entered room_exited].include?(type) ? entry_channel_id : channel_id
+
     post_message({
       embeds: [ {
         title: label[:title],
@@ -193,10 +200,11 @@ class DiscordNotifier
         color: label[:color],
         timestamp: Time.current.iso8601
       } ]
-    })
+    }, target_channel_id: target)
   end
 
   private_class_method :post_message, :format_user_mention, :format_date_time,
                        :send_reservation_notification, :send_key_notification,
-                       :send_room_notification, :bot_token, :channel_id
+                       :send_room_notification, :bot_token, :channel_id,
+                       :entry_channel_id
 end

--- a/app/views/admin/_nav.html.erb
+++ b/app/views/admin/_nav.html.erb
@@ -3,7 +3,7 @@
   <% current_path = request.path %>
   <% nav_items = [
     { label: "ユーザー管理", path: admin_roles_path },
-    { label: "NFC情報", path: admin_nfc_cards_path },
+    { label: "学生証情報", path: admin_nfc_cards_path },
     { label: "譲渡履歴", path: admin_key_transfer_logs_path },
     { label: "施錠アナウンス", path: edit_admin_scheduled_announcement_path },
     { label: "アップデート情報", path: admin_app_updates_path }

--- a/app/views/admin/nfc_cards/index.html.erb
+++ b/app/views/admin/nfc_cards/index.html.erb
@@ -3,7 +3,7 @@
 
 <%= render "admin/nav" %>
 
-<h2 class="text-xl font-bold text-gray-800">NFC情報</h2>
+<h2 class="text-xl font-bold text-gray-800">学生証情報</h2>
 
 <!-- デスクトップ: テーブル表示 -->
 <div class="hidden md:block overflow-x-auto card">
@@ -66,7 +66,7 @@
 
 <% if @nfc_cards.empty? %>
   <div class="card p-8 text-center text-gray-400">
-    登録されているNFCカードはありません
+    登録されている学生証はありません
   </div>
 <% else %>
   <p class="text-sm text-gray-600 mt-4">

--- a/app/views/admin/users/show.html.erb
+++ b/app/views/admin/users/show.html.erb
@@ -88,9 +88,9 @@
     </div>
   </div>
 
-  <!-- NFCカード情報 -->
+  <!-- 学生証情報 -->
   <div class="card p-6">
-    <h2 class="text-lg font-bold text-gray-800 mb-4">NFCカード情報</h2>
+    <h2 class="text-lg font-bold text-gray-800 mb-4">学生証情報</h2>
     <% if @user.nfc_card %>
       <div class="space-y-3">
         <div>
@@ -115,7 +115,7 @@
         </div>
       </div>
     <% else %>
-      <p class="text-sm text-gray-400">NFCカード未登録</p>
+      <p class="text-sm text-gray-400">学生証未登録</p>
     <% end %>
   </div>
 

--- a/app/views/dashboard/landing.html.erb
+++ b/app/views/dashboard/landing.html.erb
@@ -31,7 +31,7 @@
           </div>
           <h3 class="text-lg font-bold text-gray-800 mb-2">部室状況</h3>
           <p class="text-sm text-gray-600 leading-relaxed">
-            今だれが部室にいるか、開室中かをリアルタイムで確認。NFCカードで入退室を自動記録します。
+            今だれが部室にいるか、開室中かをリアルタイムで確認。学生証で入退室を自動記録します。
           </p>
         </div>
 
@@ -97,8 +97,8 @@
               <span class="text-xl">🪪</span>
             </div>
             <div>
-              <h3 class="text-base font-bold text-gray-800 mb-1">NFCカード対応</h3>
-              <p class="text-sm text-gray-600">カードをかざすだけで入退室を記録。学生証もそのまま使えます。</p>
+              <h3 class="text-base font-bold text-gray-800 mb-1">学生証対応</h3>
+              <p class="text-sm text-gray-600">学生証をかざすだけで入退室を自動記録します。</p>
             </div>
           </div>
         </div>
@@ -143,7 +143,7 @@
         <div class="flex items-start gap-4">
           <div class="w-8 h-8 bg-blue-600 text-white rounded-full flex items-center justify-center shrink-0 text-sm font-bold">3</div>
           <div class="card flex-1 p-4">
-            <h3 class="text-sm font-bold text-gray-800">NFCカードを登録</h3>
+            <h3 class="text-sm font-bold text-gray-800">学生証を登録</h3>
             <p class="text-xs text-gray-600 mt-1">カードを登録すると、入退室が自動で記録されるようになります。</p>
           </div>
         </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -103,7 +103,7 @@
               <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.25 7.5A2.25 2.25 0 014.5 5.25h15A2.25 2.25 0 0121.75 7.5v9A2.25 2.25 0 0119.5 18.75h-15A2.25 2.25 0 012.25 16.5v-9zm0 3h19.5m-13.5 4.5h3"></path>
               </svg>
-              <span class="text-sm font-medium">NFCカード</span>
+              <span class="text-sm font-medium">学生証</span>
               <% if current_user && !current_user.nfc_card %>
                 <span class="ml-auto text-xs text-red-500 font-medium">未登録</span>
               <% end %>
@@ -163,7 +163,7 @@
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.25 7.5A2.25 2.25 0 014.5 5.25h15A2.25 2.25 0 0121.75 7.5v9A2.25 2.25 0 0119.5 18.75h-15A2.25 2.25 0 012.25 16.5v-9zm0 3h19.5m-13.5 4.5h3"></path>
             </svg>
-            <span class="text-sm font-medium">NFCカード</span>
+            <span class="text-sm font-medium">学生証</span>
             <% if current_user && !current_user.nfc_card %>
               <span class="ml-auto text-xs text-red-500 font-medium">未登録</span>
             <% end %>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -103,7 +103,7 @@
               <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.25 7.5A2.25 2.25 0 014.5 5.25h15A2.25 2.25 0 0121.75 7.5v9A2.25 2.25 0 0119.5 18.75h-15A2.25 2.25 0 012.25 16.5v-9zm0 3h19.5m-13.5 4.5h3"></path>
               </svg>
-              <span class="text-sm font-medium">学生証</span>
+              <span class="text-sm font-medium">学生証管理</span>
               <% if current_user && !current_user.nfc_card %>
                 <span class="ml-auto text-xs text-red-500 font-medium">未登録</span>
               <% end %>
@@ -163,7 +163,7 @@
             <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.25 7.5A2.25 2.25 0 014.5 5.25h15A2.25 2.25 0 0121.75 7.5v9A2.25 2.25 0 0119.5 18.75h-15A2.25 2.25 0 012.25 16.5v-9zm0 3h19.5m-13.5 4.5h3"></path>
             </svg>
-            <span class="text-sm font-medium">学生証</span>
+            <span class="text-sm font-medium">学生証管理</span>
             <% if current_user && !current_user.nfc_card %>
               <span class="ml-auto text-xs text-red-500 font-medium">未登録</span>
             <% end %>

--- a/app/views/nfc_cards/index.html.erb
+++ b/app/views/nfc_cards/index.html.erb
@@ -53,7 +53,7 @@
     <h2 class="text-lg font-bold text-gray-800 mb-4">学生証を登録</h2>
     <p class="text-sm text-gray-600 mb-4">
       登録を開始すると1分間カードの読み取り待ち状態になります。<br>
-      部室のNFCリーダーに学生証をかざしてください。
+      部室のカードリーダーに学生証をかざしてください。
     </p>
 
     <!-- 登録前 -->
@@ -123,14 +123,14 @@
         <h3 class="text-sm font-bold text-gray-700 mb-2">学生証の登録方法</h3>
         <ol class="text-sm text-gray-600 list-decimal list-inside space-y-1">
           <li>「カード登録を開始」ボタンを押す</li>
-          <li>1分以内に部室のNFCリーダーに学生証をかざす</li>
+          <li>1分以内に部室のカードリーダーに学生証をかざす</li>
           <li>画面に表示されたカード情報を確認して「登録する」を押す</li>
         </ol>
       </div>
       <div>
         <h3 class="text-sm font-bold text-gray-700 mb-2">入退室の仕方</h3>
         <p class="text-sm text-gray-600">
-          登録済みの学生証を部室のNFCリーダーにかざすだけで入退室できます。<br>
+          登録済みの学生証を部室のカードリーダーにかざすだけで入退室できます。<br>
           かざすたびに入室と退室が自動で切り替わります。
         </p>
       </div>

--- a/app/views/nfc_cards/index.html.erb
+++ b/app/views/nfc_cards/index.html.erb
@@ -1,5 +1,5 @@
 <div class="space-y-6 px-4 py-6 md:px-8">
-  <h1 class="text-2xl font-bold text-gray-800">🪪 NFCカード管理</h1>
+  <h1 class="text-2xl font-bold text-gray-800">🪪 学生証管理</h1>
 
   <!-- Flash Messages -->
   <% if flash[:notice] %>
@@ -23,7 +23,7 @@
           <svg class="w-5 h-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.25 7.5A2.25 2.25 0 014.5 5.25h15A2.25 2.25 0 0121.75 7.5v9A2.25 2.25 0 0119.5 18.75h-15A2.25 2.25 0 012.25 16.5v-9zm0 3h19.5m-13.5 4.5h3"></path>
           </svg>
-          <span class="text-xs font-medium text-gray-500">NFC Card</span>
+          <span class="text-xs font-medium text-gray-500">学生証</span>
         </div>
         <span class="text-xs text-gray-500"><%= @nfc_card.created_at.in_time_zone("Asia/Tokyo").strftime("%Y/%m/%d") %> 登録</span>
       </div>
@@ -85,7 +85,7 @@
           <svg class="w-5 h-5 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
             <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M2.25 7.5A2.25 2.25 0 014.5 5.25h15A2.25 2.25 0 0121.75 7.5v9A2.25 2.25 0 0119.5 18.75h-15A2.25 2.25 0 012.25 16.5v-9zm0 3h19.5m-13.5 4.5h3"></path>
           </svg>
-          <span class="text-xs font-medium text-gray-500">NFC Card</span>
+          <span class="text-xs font-medium text-gray-500">学生証</span>
         </div>
         <div id="detected-card-info" class="mb-3 hidden"></div>
         <p class="text-xs font-mono text-gray-500 tracking-wider"><span id="detected-card-uid"></span></p>

--- a/app/views/stats/ranking.html.erb
+++ b/app/views/stats/ranking.html.erb
@@ -57,10 +57,11 @@
       </div>
     <% else %>
       <div class="divide-y divide-gray-100">
-        <% @ranking.each_with_index do |entry, i| %>
+        <% @ranking.each do |entry| %>
+          <% rank = entry[:rank] %>
           <div class="flex items-center gap-4 px-5 py-3">
-            <span class="w-8 text-center text-lg font-bold <%= i < 3 ? 'text-2xl' : 'text-gray-400' %>">
-              <%= rank_medal(i) %>
+            <span class="w-8 text-center text-lg font-bold <%= rank <= 3 ? 'text-2xl' : 'text-gray-400' %>">
+              <%= rank_medal(rank) %>
             </span>
             <% if entry[:user] %>
               <%= render(UserAvatarComponent.new(user: entry[:user], size: :small)) %>

--- a/discord-bot/src/api.ts
+++ b/discord-bot/src/api.ts
@@ -107,6 +107,7 @@ export interface RankingEntry {
 	discord_id?: string;
 	count?: number;
 	total_seconds?: number;
+	rank?: number;
 }
 
 export interface RankingResponse {

--- a/discord-bot/src/api.ts
+++ b/discord-bot/src/api.ts
@@ -87,9 +87,14 @@ export interface MyStatsRoom {
 	total_seconds: number;
 }
 
-export interface MyStatsRank {
+export interface MyStatsRankEntry {
 	position: number | null;
 	total_users: number;
+}
+
+export interface MyStatsRank {
+	visit: MyStatsRankEntry;
+	duration: MyStatsRankEntry;
 	period: string;
 }
 

--- a/discord-bot/src/commands/me.ts
+++ b/discord-bot/src/commands/me.ts
@@ -36,8 +36,14 @@ export const meCommand = {
             const lines: string[] = [];
 
             // ランキング順位
-            if (data.rank.position !== null) {
-                lines.push(`🏅 訪問日数ランキング: **${data.rank.position}位** / ${data.rank.total_users}人中（${PERIOD_LABELS[data.rank.period] ?? data.rank.period}）`);
+            const rankPeriodLabel = PERIOD_LABELS[data.rank.period] ?? data.rank.period;
+            if (data.rank.visit.position !== null) {
+                lines.push(`🏅 訪問日数ランキング: **${data.rank.visit.position}位** / ${data.rank.visit.total_users}人中（${rankPeriodLabel}）`);
+            }
+            if (data.rank.duration.position !== null) {
+                lines.push(`⏱️ 滞在時間ランキング: **${data.rank.duration.position}位** / ${data.rank.duration.total_users}人中（${rankPeriodLabel}）`);
+            }
+            if (data.rank.visit.position !== null || data.rank.duration.position !== null) {
                 lines.push('');
             }
 

--- a/discord-bot/src/commands/rank.ts
+++ b/discord-bot/src/commands/rank.ts
@@ -13,11 +13,11 @@ function formatDuration(totalSeconds: number): string {
     return `${minutes}分`;
 }
 
-function rankEmoji(index: number): string {
-    if (index === 0) return '🥇';
-    if (index === 1) return '🥈';
-    if (index === 2) return '🥉';
-    return `**${index + 1}.**`;
+function rankEmoji(rank: number): string {
+    if (rank === 1) return '🥇';
+    if (rank === 2) return '🥈';
+    if (rank === 3) return '🥉';
+    return `**${rank}.**`;
 }
 
 export const rankCommand = {
@@ -44,12 +44,13 @@ export const rankCommand = {
             const periodLabel = PERIOD_LABELS[period] ?? period;
             const title = `📊 ${typeLabel}ランキング（${periodLabel} / ${roomLabel}）`;
 
-            const lines = data.ranking.map((entry: RankingEntry, i: number) => {
+            const lines = data.ranking.map((entry: RankingEntry) => {
+                const rank = entry.rank ?? 0;
                 const name = entry.display_name ?? '不明なユーザー';
                 const value = type === 'visits'
                     ? `${entry.count}日`
                     : formatDuration(entry.total_seconds ?? 0);
-                return `${rankEmoji(i)} ${name} — ${value}`;
+                return `${rankEmoji(rank)} ${name} — ${value}`;
             });
 
             return replyEmbed(title, lines.join('\n'));


### PR DESCRIPTION
登録は学生証Onlyに変更
入退室の通知チャンネルを分離
絵文字で開閉通知
ランキングの同順修正

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **New Features**
  * 訪問日数と滞在時間の別々のランキングを表示するようになりました。

* **Bug Fixes**
  * 学生証登録時の入力検証を強化し、不正な登録を早期に検出するようにしました。
  * 削除/登録時の成功・エラーメッセージを「学生証」表記に統一しました。

* **UI Updates**
  * アプリ内表記を「NFCカード」から「学生証」へ一貫して変更しました。
  * ランキング表示で順位メダルや順位表記が適切に表示されるよう改善しました。

* **Other**
  * Discord通知が用途に応じて別チャネルへ送信され、絵文字を用いた簡潔な通知に変更されました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->