### PR TITLE
DB周りの最適化

### DIFF
--- a/app/models/scheduled_announcement.rb
+++ b/app/models/scheduled_announcement.rb
@@ -7,8 +7,7 @@ class ScheduledAnnouncement < ApplicationRecord
   validates :hour, presence: true, inclusion: { in: 0..23 }
   validates :minute, presence: true, inclusion: { in: 0..59 }
 
-  after_save { Rails.cache.delete("scheduled_announcement") }
-  after_destroy { Rails.cache.delete("scheduled_announcement") }
+  after_commit(on: %i[create update destroy]) { Rails.cache.delete("scheduled_announcement") }
 
   # シングルトンレコード（1件のみ使用）
   def self.current

--- a/app/models/scheduled_announcement.rb
+++ b/app/models/scheduled_announcement.rb
@@ -7,6 +7,9 @@ class ScheduledAnnouncement < ApplicationRecord
   validates :hour, presence: true, inclusion: { in: 0..23 }
   validates :minute, presence: true, inclusion: { in: 0..59 }
 
+  after_save { Rails.cache.delete("scheduled_announcement") }
+  after_destroy { Rails.cache.delete("scheduled_announcement") }
+
   # シングルトンレコード（1件のみ使用）
   def self.current
     first_or_create!(

--- a/config/database.yml
+++ b/config/database.yml
@@ -18,7 +18,7 @@ default: &default
   host: <%= ENV.fetch("DB_HOST") { ENV.fetch("PGHOST", "localhost") } %>
   username: <%= ENV["DB_USERNAME"] %>
   password: <%= ENV["DB_PASSWORD"] %>
-  max_connections: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
 
 
 development:

--- a/config/initializers/scheduler.rb
+++ b/config/initializers/scheduler.rb
@@ -12,7 +12,9 @@ scheduler = Rufus::Scheduler.singleton
 # 毎分チェックして、設定された時刻と一致したら施錠アナウンスを実行
 scheduler.cron("* * * * * Asia/Tokyo") do
   now = Time.current.in_time_zone("Asia/Tokyo")
-  announcement = ScheduledAnnouncement.find_by(enabled: true)
+  announcement = Rails.cache.fetch("scheduled_announcement") do
+    ScheduledAnnouncement.find_by(enabled: true)
+  end
   next unless announcement
   next unless now.hour == announcement.hour && now.min == announcement.minute
 


### PR DESCRIPTION
NeonDBのComputeが無料枠分超過しそうな勢いだったのでDB周り改修

- スケジューあるアナウンスで毎分DBクエリが走っていたのでキャッシュ化
- 接続プール設定を修正して最大接続数を5本に変更
- Neon DBのCompute settingsが最大2CUに設定されており、オーバースペックだったため最大0.25CUに変更

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Chores**
  * スケジュール済みアナウンスメントのキャッシュ導入と更新・削除時のキャッシュ無効化を追加し、表示の整合性を向上しました。
  * データベース接続設定を見直し、接続プールの設定を改善しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->