### PR TITLE
強制退室を代理退室に名称変更

### DIFF
--- a/app/controllers/room_statuses_controller.rb
+++ b/app/controllers/room_statuses_controller.rb
@@ -95,7 +95,7 @@ class RoomStatusesController < ApplicationController
       user: user,
       source: "forced",
       exited_by: current_user,
-      notification_type: "room_forced_exited"
+      notification_type: "room_exited"
     )
     redirect_to room_statuses_path, notice: "#{user.display_name}を#{@room.name}から退室させました"
   rescue RoomEntryService::EntryError => e

--- a/app/helpers/room_statuses_helper.rb
+++ b/app/helpers/room_statuses_helper.rb
@@ -8,7 +8,7 @@ module RoomStatusesHelper
     when "web"
       "Web"
     when "forced"
-      "強制退室"
+      "代理退室"
     when "room_close"
       "一斉退室"
     else

--- a/app/services/discord_notifier.rb
+++ b/app/services/discord_notifier.rb
@@ -212,23 +212,21 @@ class DiscordNotifier
       exited_by = format_user_mention(data[:exited_by_discord_id], data[:exited_by_display_name])
       source_label = case data[:source]
       when "nfc"
-                       "NFCタッチ"
+        "NFCタッチ"
       when "web"
-                       "Webアプリ"
+        "Webアプリ"
       when "room_close"
-                       "閉室時の一斉退室"
+        "閉室時の一斉退室"
       when "forced"
-"管理者による代理退室"
-       when "forced"
-                        "管理者による代理退室"
-       else
-                        "不明"
-       end
+        "#{exited_by}による代理退室"
+      else
+        "不明"
+      end
 
-description = "🚪 #{room_name}\n👤 #{user}"
-       if type == "room_exited"
-         description += "\n⏏️ #{source_label}"
-       end
+      description = "🚪 #{room_name}\n👤 #{user}"
+      if type == "room_exited" && source_label.present?
+        description += "\n⏏️ #{source_label}"
+      end
 
       post_message({
         embeds: [ {

--- a/app/services/discord_notifier.rb
+++ b/app/services/discord_notifier.rb
@@ -19,9 +19,8 @@ class DiscordNotifier
   }.freeze
 
   ROOM_LABELS = {
-    "room_entered" => { title: "📱 入室しました", color: 0x00cc66 },
-    "room_exited" => { title: "📱 退室しました", color: 0xff9900 },
-    "room_forced_exited" => { title: "⛔ 代理退室されました", color: 0xff3333 },
+    "room_entered" => { title: "🟢 入室しました", color: 0x00cc66 },
+    "room_exited" => { title: "🟠 退室しました", color: 0xff9900 },
     "room_opened" => { title: "🔓 部室が開きました", color: 0x0099ff },
     "room_closed" => { title: "🔒 部室が閉まりました", color: 0xff3333 }
   }.freeze
@@ -199,7 +198,7 @@ class DiscordNotifier
 
   def self.send_room_notification(type, data)
     # 入退室は専用チャンネル、開閉は通常チャンネル
-    target = %w[room_entered room_exited room_forced_exited].include?(type) ? entry_channel_id : channel_id
+    target = %w[room_entered room_exited].include?(type) ? entry_channel_id : channel_id
 
     # 開閉通知はカスタム絵文字で送信
     if %w[room_opened room_closed].include?(type)
@@ -226,12 +225,10 @@ class DiscordNotifier
                         "不明"
        end
 
-       description = "🚪 #{room_name}\n👤 #{user}"
-       if type == "room_forced_exited"
-         description += "\n⏏️ #{exited_by}による代理退室"
-      elsif type == "room_exited"
-        description += "\n⏏️ #{source_label}"
-      end
+description = "🚪 #{room_name}\n👤 #{user}"
+       if type == "room_exited"
+         description += "\n⏏️ #{source_label}"
+       end
 
       post_message({
         embeds: [ {

--- a/app/services/discord_notifier.rb
+++ b/app/services/discord_notifier.rb
@@ -21,7 +21,7 @@ class DiscordNotifier
   ROOM_LABELS = {
     "room_entered" => { title: "📱 入室しました", color: 0x00cc66 },
     "room_exited" => { title: "📱 退室しました", color: 0xff9900 },
-    "room_forced_exited" => { title: "⛔ 強制退室されました", color: 0xff3333 },
+    "room_forced_exited" => { title: "⛔ 代理退室されました", color: 0xff3333 },
     "room_opened" => { title: "🔓 部室が開きました", color: 0x0099ff },
     "room_closed" => { title: "🔒 部室が閉まりました", color: 0xff3333 }
   }.freeze
@@ -219,14 +219,16 @@ class DiscordNotifier
       when "room_close"
                        "閉室時の一斉退室"
       when "forced"
-                       "管理者による強制退室"
-      else
-                       "不明"
-      end
+"管理者による代理退室"
+       when "forced"
+                        "管理者による代理退室"
+       else
+                        "不明"
+       end
 
-      description = "🚪 #{room_name}\n👤 #{user}"
-      if type == "room_forced_exited"
-        description += "\n⏏️ #{exited_by}による強制退室"
+       description = "🚪 #{room_name}\n👤 #{user}"
+       if type == "room_forced_exited"
+         description += "\n⏏️ #{exited_by}による代理退室"
       elsif type == "room_exited"
         description += "\n⏏️ #{source_label}"
       end

--- a/app/services/room_entry_service.rb
+++ b/app/services/room_entry_service.rb
@@ -85,7 +85,7 @@ class RoomEntryService
   # @param user [User]
   # @param source [String] "nfc", "web", "forced", "room_close"
   # @param exited_by [User, nil] 退室処理を実行したユーザー
-  # @param notification_type [String] "room_exited", "room_forced_exited"
+  # @param notification_type [String] "room_exited"
   # @return [RoomVisit]
   def self.exit(room:, user:, source: "web", exited_by: nil, notification_type: "room_exited")
     auto_closed = false

--- a/app/views/room_statuses/index.html.erb
+++ b/app/views/room_statuses/index.html.erb
@@ -58,7 +58,7 @@
                     <span class="text-xs text-blue-600 font-medium">あなた</span>
                   <% end %>
                   <% if effective_admin_or_manager? %>
-                    <%= button_to "強制退室", force_exit_user_room_status_path(data[:room], user_id: occupant[:user].id),
+                    <%= button_to "代理退室", force_exit_user_room_status_path(data[:room], user_id: occupant[:user].id),
                           class: "px-2 py-1 bg-red-100 hover:bg-red-200 text-red-700 text-xs font-medium rounded transition-colors",
                           form: { onsubmit: "return confirm('#{j(occupant[:user].display_name)}を#{j(data[:room].name)}から退室させますか？')" } %>
                   <% end %>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  - 管理者による退室アクション時のボタンラベルを「代理退室」に更新しました
  - 退室通知のテキストと絵文字を改善しました
  - 退室源の表示ラベルを更新しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->