### PR TITLE
fix: クライアントアプリのDiscordログイン State cookie not found エラーを修正

### DIFF
--- a/app/controllers/auth_controller.rb
+++ b/app/controllers/auth_controller.rb
@@ -20,22 +20,13 @@ class AuthController < ApplicationController
       session[:return_to] = sanitized if sanitized.present?
     end
 
-    state = SecureRandom.hex(16)
-    session[:oauth_state] = state
-
-    authorization_url = JyogiAuthClient.authorization_url(state: state)
+    authorization_url = JyogiAuthClient.authorization_url
     redirect_to authorization_url, allow_other_host: true
   end
 
   # GET /auth/callback
   # OAuth2コールバック処理
   def callback
-    # stateパラメータ検証（CSRF対策）
-    unless valid_state?
-      redirect_to error_redirect_url("Invalid state parameter"), allow_other_host: true
-      return
-    end
-
     code = params[:code]
     unless code
       redirect_to error_redirect_url("Authorization code not found"), allow_other_host: true
@@ -95,12 +86,6 @@ class AuthController < ApplicationController
   end
 
   private
-
-  def valid_state?
-    stored_state = session[:oauth_state]
-    received_state = params[:state]
-    stored_state.present? && received_state.present? && stored_state == received_state
-  end
 
   def find_or_create_user(user_info)
     jyogi_user_id = user_info["id"]

--- a/app/services/jyogi_auth_client.rb
+++ b/app/services/jyogi_auth_client.rb
@@ -14,14 +14,13 @@ class JyogiAuthClient
   TIMEOUT_SECONDS = 10
 
   # OAuth2認可URLを生成
-  def self.authorization_url(state:)
+  def self.authorization_url
     config = JyogiAuth.configuration
     uri = URI(config.authorize_url)
     params = {
       client_id: config.client_id,
       redirect_uri: config.redirect_uri,
-      response_type: "code",
-      state: state
+      response_type: "code"
     }
     uri.query = URI.encode_www_form(params)
     uri.to_s


### PR DESCRIPTION
## Summary

- `rooms.jyogi.net` でDiscordログインすると `State cookie not found` エラーが発生していた問題を修正
- Rooms側で独自にOAuth2 stateを生成・セッション保存し、コールバックで検証していたが、認証サーバー（jyogi-discord-auth）が独自にstateを生成するため不一致が発生していた
- CSRF対策は認証サーバー側の `oauth_state` cookieで完結しているため、Rooms側のstate管理を削除

## 原因

1. `AuthController#login` でRooms側が `state = SecureRandom.hex(16)` を生成しセッションに保存
2. `/oauth/authorize` 経由でユーザー未ログインの場合、認証サーバーの `/auth/login` が**別のstateを新たに生成**してDiscordへリダイレクト
3. Discordから返ってくるstateは認証サーバーが生成したもの → Rooms側のセッションのstateと不一致
4. `valid_state?` で検証失敗 → `State cookie not found` エラー

## 変更内容

- `app/controllers/auth_controller.rb`: `login`でのstate生成・保存を削除、`callback`での`valid_state?`チェックを削除、`valid_state?`メソッドを削除
- `app/services/jyogi_auth_client.rb`: `authorization_url`の`state:`引数を削除

## Test plan

- [ ] `rooms.jyogi.net` でDiscordログインボタンを押してログインが正常に完了することを確認
- [ ] ログアウト後に再ログインできることを確認