### PR TITLE
fix(discord-bot): 閲覧ログを Service Binding 経由に（Cloudflare error 1042 回避）

### DIFF
--- a/discord-bot/src/commands/types.ts
+++ b/discord-bot/src/commands/types.ts
@@ -30,8 +30,8 @@ export interface Interaction {
 export interface CommandEnv {
     API_BASE_URL: string;
     API_ACCESS_TOKEN: string;
-    // 閲覧ログ取り込み Worker（未設定なら記録は no-op）
-    INGEST_URL?: string;
+    // 閲覧ログ取り込み Worker への Service Binding（未設定なら記録は no-op）
+    VIEW_LOG?: Fetcher;
     INGEST_SHARED_SECRET?: string;
 }
 

--- a/discord-bot/src/viewLog.ts
+++ b/discord-bot/src/viewLog.ts
@@ -1,27 +1,28 @@
 // 閲覧ログ取り込み Worker (view-log-worker) への送信クライアント。
 // /status 実行時に「誰がいつ見たか」を記録する。失敗してもコマンド応答には影響させない。
+//
+// Worker→Worker は Service Binding(env.VIEW_LOG) 経由で呼ぶ。公開 workers.dev URL への
+// fetch は Cloudflare error 1042 でブロックされるため。バインディング先の pathname だけが
+// ルーティングに使われる（ホスト名は任意）。
 
 export interface ViewLogEnv {
-	INGEST_URL?: string;
+	VIEW_LOG?: Fetcher;
 	INGEST_SHARED_SECRET?: string;
 }
 
-const VIEW_LOG_TIMEOUT_MS = 5000;
+// Service Binding のルーティングに使う内部URL（ホストは任意・pathname のみ意味を持つ）
+const INGEST_URL = 'https://view-log-worker.internal/view-logs';
 
 // Discord 経路の閲覧を記録する。
 // 5分窓の重複間引き（throttle）は取り込み Worker 側で行われる。
 export async function logDiscordView(env: ViewLogEnv, discordUserId: string): Promise<void> {
-	const url = env.INGEST_URL;
+	const service = env.VIEW_LOG;
 	const secret = env.INGEST_SHARED_SECRET;
-	if (!url || !secret) return; // 未設定なら no-op
-
-	const controller = new AbortController();
-	const timeoutId = setTimeout(() => controller.abort(), VIEW_LOG_TIMEOUT_MS);
+	if (!service || !secret) return; // 未設定なら no-op
 
 	try {
-		const response = await fetch(url, {
+		const response = await service.fetch(INGEST_URL, {
 			method: 'POST',
-			signal: controller.signal,
 			headers: {
 				'Content-Type': 'application/json',
 				'X-Ingest-Secret': secret,
@@ -37,7 +38,5 @@ export async function logDiscordView(env: ViewLogEnv, discordUserId: string): Pr
 		}
 	} catch (error) {
 		console.error('view-log ingest error:', error);
-	} finally {
-		clearTimeout(timeoutId);
 	}
 }

--- a/discord-bot/src/worker.ts
+++ b/discord-bot/src/worker.ts
@@ -8,8 +8,8 @@ export interface Env {
 	DISCORD_BOT_TOKEN: string;
 	API_ACCESS_TOKEN: string;
 	API_BASE_URL: string;
-	// 閲覧ログ取り込み Worker（未設定なら記録は no-op）
-	INGEST_URL?: string;
+	// 閲覧ログ取り込み Worker への Service Binding（未設定なら記録は no-op）
+	VIEW_LOG?: Fetcher;
 	INGEST_SHARED_SECRET?: string;
 }
 

--- a/discord-bot/wrangler.toml
+++ b/discord-bot/wrangler.toml
@@ -5,8 +5,13 @@ compatibility_flags = ["nodejs_compat"]
 
 [vars]
 API_BASE_URL = "https://rooms.jyogi.net/api"
-# 閲覧ログ取り込み Worker の URL（/view-logs を含む完全URL）
-INGEST_URL = "https://jyogi-view-log-worker.jyogi.workers.dev/view-logs"
+
+# 閲覧ログ取り込み Worker へは Service Binding で接続する。
+# Worker→Worker を公開 workers.dev URL で fetch すると Cloudflare error 1042 で
+# ブロックされるため、内部バインディング(env.VIEW_LOG.fetch)を使う。
+[[services]]
+binding = "VIEW_LOG"
+service = "jyogi-view-log-worker"
 
 # INGEST_SHARED_SECRET は平文で置かず secret として設定すること:
 #   wrangler secret put INGEST_SHARED_SECRET


### PR DESCRIPTION
## 問題
Discord の `/status` を叩いても閲覧ログ（`source=discord`）が記録されなかった。

bot 側ログに以下が出ていた:
```
view-log ingest failed: 404 error code: 1042
```

**原因**: bot(Worker) → view-log-worker(Worker) を公開 `workers.dev` URL で `fetch` すると、Cloudflare が Worker 間リクエストを **error 1042** でブロックする。リクエストが取り込み Worker に到達していなかった。

（Rails → worker は外部からの HTTP なので 1042 の対象外。従来どおり記録できていた。）

## 修正
Worker→Worker の正しい方法である **Service Binding** に変更。

- `wrangler.toml`: `INGEST_URL` var を廃止し `[[services]] binding=VIEW_LOG service=jyogi-view-log-worker` を追加
- `worker.ts` / `commands/types.ts`: env を `VIEW_LOG?: Fetcher` に変更
- `viewLog.ts`: `env.VIEW_LOG.fetch(内部URL)` で送信（`X-Ingest-Secret` は引き続き付与）

## 検証（実機）
- `/status` 実行 → view-log-worker の tail に `POST /view-logs - Ok`（Service Binding 経由）
- D1 に `source=discord` の行を確認（discord_id が管理画面で表示名に解決される）
- 再デプロイ済み（jyogi-rooms-bot version 7cfc66bb）

https://claude.ai/code/session_01E3J8cVRy4imtmyiDTrTazk