### PR TITLE
feat: 閲覧ログの記録契機をホーム→部室状況画面に変更

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -7,9 +7,6 @@ class DashboardController < ApplicationController
       return
     end
 
-    # 部室状況の閲覧ログ（非同期・ベストエフォート。表示処理はブロックしない）
-    RoomViewLogger.log_web_view(current_user)
-
     @reservations = Reservation.where("end_at > ?", Time.zone.now).includes(:user).order(:start_at).limit(10)
     @rooms = Room.includes(keys: :user).order(room_number: :desc)
 

--- a/app/controllers/room_statuses_controller.rb
+++ b/app/controllers/room_statuses_controller.rb
@@ -6,6 +6,9 @@ class RoomStatusesController < ApplicationController
 
   # GET /room_statuses
   def index
+    # 部室状況の閲覧ログ（非同期・ベストエフォート。表示処理はブロックしない）
+    RoomViewLogger.log_web_view(current_user)
+
     @rooms = Room.includes(:room_status, keys: :user).order(room_number: :desc)
 
     all_statuses = @rooms.map(&:room_status).compact


### PR DESCRIPTION
## 背景
閲覧ログが `DashboardController#index`（ホーム / `root`）にフックされていたため、**アプリを開くと必ず記録**されてしまっていた。

## 変更
記録契機を **部室状況画面 `RoomStatusesController#index`（GET `/room_statuses`）** に移動。

- `dashboard#index`: `RoomViewLogger.log_web_view(current_user)` を削除
- `room_statuses#index`: 同呼び出しを追加

## 考慮点
- `room_statuses` は `authenticate_user!` 必須なので `current_user` は常に存在（`log_web_view` 自身も blank ガードあり）。
- `index` のみに限定（`logs` や `exit_room`/`close_room` 等の POST では記録しない）。
- throttle(5分/ユーザー)・`source="web"`・Worker/D1/Discord 経路は変更なし。
- 部室状況ページに自動更新は無く、1アクセス=1描画のため過剰記録なし。
- 既存データ（過去のホーム閲覧分）はそのまま。以降が部室状況画面ベースになる。

## 検証
- 両コントローラ構文OK / フックは room_statuses のみ / Rails 起動確認（BOOT_OK）
- 手動確認手順: ホーム(`/`)を開いても記録されない、`/room_statuses` を開くと1件記録（5分throttle）

https://claude.ai/code/session_01E3J8cVRy4imtmyiDTrTazk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改善**
  - 部室状況画面の閲覧記録処理を、より適切な画面に移行しました。
  - 部室状況や予約情報の表示内容に変更はありません。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->