### PR TITLE
feat: 統計・ランキングの ON/OFF 機能（OFF時は工事中表示）

### DIFF
--- a/app/controllers/admin/settings_controller.rb
+++ b/app/controllers/admin/settings_controller.rb
@@ -1,0 +1,22 @@
+class Admin::SettingsController < Admin::BaseController
+  before_action :require_developer_admin!
+
+  def edit
+    @setting = Setting.instance
+  end
+
+  def update
+    @setting = Setting.instance
+    if @setting.update(setting_params)
+      redirect_to edit_admin_settings_path, notice: "設定を更新しました"
+    else
+      render :edit, status: :unprocessable_entity
+    end
+  end
+
+  private
+
+  def setting_params
+    params.require(:setting).permit(:stats_enabled)
+  end
+end

--- a/app/controllers/api/stats_controller.rb
+++ b/app/controllers/api/stats_controller.rb
@@ -4,6 +4,7 @@ module Api
   class StatsController < BaseController
     skip_before_action :authenticate_user!
     before_action :authenticate_api_key!
+    before_action :require_stats_enabled, only: %i[ranking me visit_days]
     include PeriodFilterable
 
     # GET /api/stats/ranking
@@ -73,6 +74,13 @@ module Api
     end
 
     private
+
+    # 統計・ランキングが無効な場合は工事中を示すレスポンスを返す（Discord Bot が判別する）
+    def require_stats_enabled
+      return if Setting.stats_enabled?
+
+      render json: { enabled: false, message: "現在工事中です" }, status: :ok
+    end
 
 def load_user_and_scope
       unless params[:discord_user_id].present?

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -3,6 +3,8 @@
 class StatsController < ApplicationController
   include PeriodFilterable
 
+  before_action :require_stats_enabled, only: %i[ranking me]
+
   # GET /stats/ranking
   def ranking
     @period = valid_period(params[:period])
@@ -61,6 +63,13 @@ class StatsController < ApplicationController
   end
 
   private
+
+  # 統計・ランキングが無効な場合は「工事中」ページを表示して処理を打ち切る
+  def require_stats_enabled
+    return if Setting.stats_enabled?
+
+    render "stats/disabled"
+  end
 
   def heatmap_start_date(period)
     end_date = Date.current

--- a/app/models/setting.rb
+++ b/app/models/setting.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# アプリ全体の設定（シングルトンレコード。1件のみ使用）
+# 例: 統計・ランキング機能の ON/OFF
+class Setting < ApplicationRecord
+  STATS_ENABLED_CACHE_KEY = "setting:stats_enabled"
+
+  after_commit :clear_stats_enabled_cache, on: %i[create update destroy]
+
+  # シングルトンレコードを取得（無ければ既定値で作成）
+  def self.instance
+    first_or_create!
+  end
+
+  # 統計・ランキング機能が有効か（頻繁に参照するためキャッシュ）
+  def self.stats_enabled?
+    Rails.cache.fetch(STATS_ENABLED_CACHE_KEY) { instance.stats_enabled }
+  end
+
+  private
+
+  def clear_stats_enabled_cache
+    Rails.cache.delete(STATS_ENABLED_CACHE_KEY)
+  end
+end

--- a/app/views/admin/_nav.html.erb
+++ b/app/views/admin/_nav.html.erb
@@ -9,6 +9,7 @@
     { label: "施錠アナウンス", path: edit_admin_scheduled_announcement_path }
   ] %>
   <% nav_items << { label: "アップデート情報", path: admin_app_updates_path } if effective_admin? %>
+  <% nav_items << { label: "設定", path: edit_admin_settings_path } if effective_admin? %>
   
   <select 
     onchange="if(this.value) window.location.href = this.value"

--- a/app/views/admin/settings/edit.html.erb
+++ b/app/views/admin/settings/edit.html.erb
@@ -5,20 +5,45 @@
 
   <h2 class="text-xl font-bold text-gray-800">設定</h2>
 
-  <%= form_with model: @setting, url: admin_settings_path, method: :patch, class: "card p-6 space-y-4" do |f| %>
-    <div>
-      <label class="flex items-center gap-3 cursor-pointer">
-        <%= f.check_box :stats_enabled, class: "h-5 w-5 rounded border-gray-300 text-primary focus:ring-primary" %>
-        <span class="font-medium text-gray-800">統計・ランキングを表示する</span>
-      </label>
-      <p class="text-sm text-gray-500 mt-2">
-        オフにすると、Web の統計・ランキング画面と Discord の <code>/rank</code>・<code>/me</code> が
-        「現在工事中です」と表示されます。
-      </p>
-    </div>
-
-    <div>
-      <%= f.submit "保存", class: "btn btn-primary" %>
+  <% if notice %>
+    <div class="p-3 bg-green-50 border border-green-200 rounded-lg text-sm text-green-700">
+      ✅ <%= notice %>
     </div>
   <% end %>
+
+  <div class="card p-6 space-y-4 max-w-2xl">
+    <!-- 現在の状態 -->
+    <div class="flex items-center justify-between border-b border-gray-100 pb-4">
+      <div>
+        <p class="font-medium text-gray-800">統計・ランキング</p>
+        <p class="text-sm text-gray-500">現在の状態</p>
+      </div>
+      <% if @setting.stats_enabled %>
+        <span class="inline-flex items-center gap-1 px-3 py-1 rounded-full text-sm font-medium bg-green-100 text-green-700">
+          🟢 表示中
+        </span>
+      <% else %>
+        <span class="inline-flex items-center gap-1 px-3 py-1 rounded-full text-sm font-medium bg-gray-200 text-gray-600">
+          🚧 非表示（工事中）
+        </span>
+      <% end %>
+    </div>
+
+    <%= form_with model: @setting, url: admin_settings_path, method: :patch, class: "space-y-4" do |f| %>
+      <div>
+        <label class="flex items-center gap-3 cursor-pointer">
+          <%= f.check_box :stats_enabled, class: "h-5 w-5 rounded border-gray-300 text-primary focus:ring-primary" %>
+          <span class="font-medium text-gray-800">統計・ランキングを表示する</span>
+        </label>
+        <p class="text-sm text-gray-500 mt-2">
+          オフにすると、Web の統計・ランキング画面と Discord の <code>/rank</code>・<code>/me</code> が
+          「現在工事中です」と表示されます。
+        </p>
+      </div>
+
+      <div>
+        <%= f.submit "保存", class: "btn btn-primary" %>
+      </div>
+    <% end %>
+  </div>
 </div>

--- a/app/views/admin/settings/edit.html.erb
+++ b/app/views/admin/settings/edit.html.erb
@@ -1,0 +1,24 @@
+<div class="space-y-6 px-4 py-6 md:px-8">
+  <h1 class="text-2xl font-bold text-gray-900">🛡️ 管理画面</h1>
+
+  <%= render "admin/nav" %>
+
+  <h2 class="text-xl font-bold text-gray-800">設定</h2>
+
+  <%= form_with model: @setting, url: admin_settings_path, method: :patch, class: "card p-6 space-y-4" do |f| %>
+    <div>
+      <label class="flex items-center gap-3 cursor-pointer">
+        <%= f.check_box :stats_enabled, class: "h-5 w-5 rounded border-gray-300 text-primary focus:ring-primary" %>
+        <span class="font-medium text-gray-800">統計・ランキングを表示する</span>
+      </label>
+      <p class="text-sm text-gray-500 mt-2">
+        オフにすると、Web の統計・ランキング画面と Discord の <code>/rank</code>・<code>/me</code> が
+        「現在工事中です」と表示されます。
+      </p>
+    </div>
+
+    <div>
+      <%= f.submit "保存", class: "btn btn-primary" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/stats/disabled.html.erb
+++ b/app/views/stats/disabled.html.erb
@@ -1,0 +1,10 @@
+<div class="space-y-6 px-4 py-6 md:px-8">
+  <div class="card p-10 text-center max-w-lg mx-auto">
+    <div class="text-6xl mb-4">🚧</div>
+    <h1 class="text-2xl font-bold text-gray-800 mb-2">現在工事中です</h1>
+    <p class="text-gray-600">統計・ランキング機能は一時的に利用できません。<br>しばらくお待ちください。</p>
+    <div class="mt-6">
+      <%= link_to "ホームに戻る", root_path, class: "btn btn-secondary text-sm" %>
+    </div>
+  </div>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -90,6 +90,7 @@ Rails.application.routes.draw do
     resources :app_updates, only: %i[index new create edit update destroy]
     resources :key_transfer_logs, only: %i[index show]
     resources :view_logs, only: %i[index]
+    resource :settings, only: %i[edit update]
     resource :scheduled_announcement, only: %i[edit update]
   end
 

--- a/db/migrate/20260825000000_create_settings.rb
+++ b/db/migrate/20260825000000_create_settings.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class CreateSettings < ActiveRecord::Migration[8.1]
+  def change
+    create_table :settings do |t|
+      # 統計・ランキング機能の有効/無効（既定は有効＝従来どおり）
+      t.boolean :stats_enabled, null: false, default: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_06_000000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_25_000000) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -155,6 +155,12 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_06_000000) do
     t.integer "hour", default: 20, null: false
     t.text "message", null: false
     t.integer "minute", default: 0, null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "settings", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.boolean "stats_enabled", default: true, null: false
     t.datetime "updated_at", null: false
   end
 

--- a/discord-bot/src/api.ts
+++ b/discord-bot/src/api.ts
@@ -91,6 +91,9 @@ export interface MyStatsRank {
 }
 
 export interface MyStatsResponse {
+	// 統計機能が無効な場合は enabled: false + message のみが返る
+	enabled?: boolean;
+	message?: string;
 	user: { id: number; display_name: string; discord_id?: string };
 	room: string;
 	total: { visit_days: number; total_seconds: number };
@@ -107,6 +110,9 @@ export interface RankingEntry {
 }
 
 export interface RankingResponse {
+	// 統計機能が無効な場合は enabled: false + message のみが返る
+	enabled?: boolean;
+	message?: string;
 	type: string;
 	period: string;
 	room: string;

--- a/discord-bot/src/commands/me.ts
+++ b/discord-bot/src/commands/me.ts
@@ -30,6 +30,11 @@ export const meCommand = {
             const api = createApi(env);
             const data = await api.fetchMyStats(discordUserId, room);
 
+            // 統計機能が無効（工事中）
+            if (data.enabled === false) {
+                return reply(data.message ?? '🚧 現在工事中です');
+            }
+
             const roomLabel = room === 'all' ? '全体' : `🚪第${room}部室`;
             const title = `📊 ${data.user.display_name} の部室利用統計（${roomLabel}）`;
 

--- a/discord-bot/src/commands/rank.ts
+++ b/discord-bot/src/commands/rank.ts
@@ -35,6 +35,11 @@ export const rankCommand = {
             const api = createApi(env);
             const data = await api.fetchRanking(type, period, room ?? 'all');
 
+            // 統計機能が無効（工事中）
+            if (data.enabled === false) {
+                return reply(data.message ?? '🚧 現在工事中です');
+            }
+
             if (data.ranking.length === 0) {
                 return reply('該当期間のデータがありません。');
             }


### PR DESCRIPTION
## 概要
管理画面（開発者限定）のトグルで **統計・ランキング機能を ON/OFF** できるようにする。OFF 時は Web の統計/ランキング画面と Discord の `/rank`・`/me` が **「現在工事中です」** と表示される。

対象は「ランキング」＋「自分の統計」の両方（ユーザー要望）。

## 実装
### フラグ保管
- `Setting` シングルトンモデル + `settings` テーブル（`stats_enabled boolean default true`）
- `Setting.stats_enabled?` を `Rails.cache` でキャッシュ、更新時に `after_commit` で無効化
- 既定 `true`＝従来どおり（挙動不変）

### Web
- `StatsController#ranking` / `#me`: 無効時に `stats/disabled`（🚧 現在工事中です）を描画

### API（Discord 用）
- `Api::StatsController#ranking` / `#me` / `#visit_days`: 無効時に `200 { "enabled": false, "message": "現在工事中です" }`

### Discord bot
- `rank.ts` / `me.ts`: レスポンスが `enabled === false` なら「🚧 現在工事中です」を返信
- `api.ts`: `RankingResponse` / `MyStatsResponse` に `enabled?` / `message?` を追加

### 管理画面（開発者限定）
- `Admin::SettingsController`（`edit`/`update`, `require_developer_admin!`）+ `/admin/settings` 画面（既存の空 `admin/settings` 雛形を利用）
- admin nav に「設定」リンク（`effective_admin?` のみ）

## 検証
- 統合テスト（実 routing + controller）: API ranking **ON=200 通常JSON** / **OFF=`{"enabled":false,"message":"現在工事中です"}`** を確認
- `Setting.stats_enabled?` の true/false 切替＋キャッシュ無効化を確認
- Ruby 構文 / bot typecheck OK
- 検証後、本番の設定は **有効(true) に復元済み**

## デプロイ時の注意
- **マイグレーション適用が必要**（`settings` テーブル作成）。開発DB=Neon共有のため既に適用済みだが、Raspi デプロイの `db:migrate` は冪等。
- **Discord bot の再デプロイが必要**（`rank.ts`/`me.ts` の変更反映）。develop マージ後の CI（deploy-discord-bot）で反映される。

https://claude.ai/code/session_01E3J8cVRy4imtmyiDTrTazk