### PR TITLE
feat: ランキング/統計の閲覧ログ（カテゴリで分離）

### DIFF
--- a/app/controllers/admin/view_logs_controller.rb
+++ b/app/controllers/admin/view_logs_controller.rb
@@ -1,9 +1,11 @@
 class Admin::ViewLogsController < Admin::BaseController
   DAYS = 30
   RECENT_LIMIT = 100
+  CATEGORIES = %w[room_status ranking stats].freeze
 
   def index
-    result = ViewLogStatsClient.fetch(days: DAYS, limit: RECENT_LIMIT)
+    @category = params[:category].presence_in(CATEGORIES)
+    result = ViewLogStatsClient.fetch(days: DAYS, limit: RECENT_LIMIT, category: @category)
 
     unless result.ok
       @error = result.error
@@ -36,6 +38,7 @@ class Admin::ViewLogsController < Admin::BaseController
 
       {
         source: row["source"],
+        category: row["category"],
         viewed_at: parse_time(row["viewed_at"]),
         display_name: user&.display_name,
         username: user&.username,

--- a/app/controllers/room_statuses_controller.rb
+++ b/app/controllers/room_statuses_controller.rb
@@ -7,7 +7,7 @@ class RoomStatusesController < ApplicationController
   # GET /room_statuses
   def index
     # 部室状況の閲覧ログ（非同期・ベストエフォート。表示処理はブロックしない）
-    RoomViewLogger.log_web_view(current_user)
+    RoomViewLogger.log_web_view(current_user, category: "room_status")
 
     @rooms = Room.includes(:room_status, keys: :user).order(room_number: :desc)
 

--- a/app/controllers/stats_controller.rb
+++ b/app/controllers/stats_controller.rb
@@ -7,6 +7,9 @@ class StatsController < ApplicationController
 
   # GET /stats/ranking
   def ranking
+    # 閲覧ログ（ランキング）。工事中(before_action で弾かれた)場合はここに来ない
+    RoomViewLogger.log_web_view(current_user, category: "ranking")
+
     @period = valid_period(params[:period])
     @type = params[:type].presence || "visits"
     @room_param = params[:room].presence || "all"
@@ -30,6 +33,9 @@ class StatsController < ApplicationController
 
   # GET /stats/me
   def me
+    # 閲覧ログ（統計）。工事中(before_action で弾かれた)場合はここに来ない
+    RoomViewLogger.log_web_view(current_user, category: "stats")
+
     @period = valid_period(params[:period])
 
     base_scope = RoomVisit.where(user: current_user)

--- a/app/jobs/room_view_log_job.rb
+++ b/app/jobs/room_view_log_job.rb
@@ -25,10 +25,11 @@ class RoomViewLogJob < ApplicationJob
   TIMEOUT_SECONDS = 5
 
   # @param source [String] "web" / "discord"
+  # @param category [String] "room_status" / "ranking" / "stats"
   # @param user_id [Integer, nil] Rails users.id
   # @param discord_id [String, nil] Discord ユーザーID
   # @param viewed_at [String] UTC ISO8601
-  def perform(source, user_id:, discord_id:, viewed_at:)
+  def perform(source, category:, user_id:, discord_id:, viewed_at:)
     url = ENV["VIEW_LOG_INGEST_URL"]
     secret = ENV["VIEW_LOG_INGEST_SECRET"]
     return if url.blank? || secret.blank?
@@ -39,6 +40,7 @@ class RoomViewLogJob < ApplicationJob
     request["X-Ingest-Secret"] = secret
     request.body = {
       source: source,
+      category: category,
       user_id: user_id,
       discord_id: discord_id,
       viewed_at: viewed_at

--- a/app/jobs/room_view_log_job.rb
+++ b/app/jobs/room_view_log_job.rb
@@ -29,7 +29,8 @@ class RoomViewLogJob < ApplicationJob
   # @param user_id [Integer, nil] Rails users.id
   # @param discord_id [String, nil] Discord ユーザーID
   # @param viewed_at [String] UTC ISO8601
-  def perform(source, category:, user_id:, discord_id:, viewed_at:)
+  # category は後方互換のため既定を持つ（旧シグネチャで投入済みのジョブが失敗しないように）
+  def perform(source, category: "room_status", user_id:, discord_id:, viewed_at:)
     url = ENV["VIEW_LOG_INGEST_URL"]
     secret = ENV["VIEW_LOG_INGEST_SECRET"]
     return if url.blank? || secret.blank?

--- a/app/services/room_view_logger.rb
+++ b/app/services/room_view_logger.rb
@@ -7,17 +7,22 @@
 #   ※本アプリの本番キャッシュがプロセスローカルでも、Worker 側で必ず間引かれる。
 class RoomViewLogger
   THROTTLE_WINDOW = 5.minutes
+  VALID_CATEGORIES = %w[room_status ranking stats].freeze
 
-  # ログイン中ユーザーの Web 閲覧を記録する（ダッシュボード表示時に呼ぶ）。
+  # ログイン中ユーザーの Web 閲覧を記録する。
   # メイン処理をブロック・失敗させないよう、例外は握りつぶしてログのみ。
   # @param user [User, nil]
-  def self.log_web_view(user)
+  # @param category [String] "room_status" / "ranking" / "stats"
+  def self.log_web_view(user, category: "room_status")
     return if user.blank?
     return unless enabled?
-    return unless should_enqueue?(user)
+
+    category = "room_status" unless VALID_CATEGORIES.include?(category)
+    return unless should_enqueue?(user, category)
 
     RoomViewLogJob.perform_later(
       "web",
+      category: category,
       user_id: user.id,
       discord_id: nil,
       viewed_at: Time.current.utc.iso8601
@@ -26,11 +31,11 @@ class RoomViewLogger
     Rails.logger.error("[RoomViewLogger] failed to enqueue web view log: #{e.class}: #{e.message}")
   end
 
-  # 一次throttle: 5分窓で既に投入済みならジョブを作らない。
+  # 一次throttle: 5分窓で既に投入済みならジョブを作らない（カテゴリ別）。
   # キャッシュ障害（write が例外）時は fail-open（ジョブ投入を止めない）。
   # 経路横断の最終的な重複判定は Worker 側 KV が権威なので、ここが緩くても実害はない。
-  def self.should_enqueue?(user)
-    cache_key = "view_log_throttle:web:#{user.id}"
+  def self.should_enqueue?(user, category)
+    cache_key = "view_log_throttle:web:#{category}:#{user.id}"
     # unless_exist: true → 新規書き込み成功で true、キー存在（＝throttle対象）で false
     Rails.cache.write(cache_key, true, expires_in: THROTTLE_WINDOW, unless_exist: true)
   rescue => e

--- a/app/services/view_log_stats_client.rb
+++ b/app/services/view_log_stats_client.rb
@@ -12,14 +12,17 @@ class ViewLogStatsClient
 
   # @param days [Integer] 日別集計の対象日数
   # @param limit [Integer] 最近の閲覧の取得件数
+  # @param category [String, nil] カテゴリ絞り込み（nil は全体）
   # @return [Result]
-  def self.fetch(days: 30, limit: 50)
+  def self.fetch(days: 30, limit: 50, category: nil)
     ingest_url = ENV["VIEW_LOG_INGEST_URL"]
     secret = ENV["VIEW_LOG_INGEST_SECRET"]
     return Result.new(ok: false, error: "閲覧ログ連携が未設定です（VIEW_LOG_INGEST_URL / VIEW_LOG_INGEST_SECRET）") if ingest_url.blank? || secret.blank?
 
     uri = URI("#{ingest_url}/stats")
-    uri.query = URI.encode_www_form(days: days, limit: limit)
+    query = { days: days, limit: limit }
+    query[:category] = category if category.present?
+    uri.query = URI.encode_www_form(query)
 
     request = Net::HTTP::Get.new(uri.request_uri)
     request["X-Ingest-Secret"] = secret

--- a/app/views/admin/view_logs/index.html.erb
+++ b/app/views/admin/view_logs/index.html.erb
@@ -3,7 +3,7 @@
 
   <%= render "admin/nav" %>
 
-  <h2 class="text-xl font-bold text-gray-800">部室状況の閲覧ログ</h2>
+  <h2 class="text-xl font-bold text-gray-800">閲覧ログ</h2>
 
   <% if @error %>
     <div class="card p-6 text-center text-gray-600">
@@ -11,23 +11,56 @@
       <p class="text-sm text-gray-500 mt-2">閲覧ログは Cloudflare (view-log-worker) 側に保存されています。連携設定を確認してください。</p>
     </div>
   <% else %>
-    <!-- サマリー -->
+    <%
+      category_meta = {
+        "room_status" => { label: "部室状況", emoji: "🚪", badge: "bg-emerald-100 text-emerald-700" },
+        "ranking"     => { label: "ランキング", emoji: "👑", badge: "bg-amber-100 text-amber-700" },
+        "stats"       => { label: "統計", emoji: "📊", badge: "bg-sky-100 text-sky-700" }
+      }
+      by_category = (@stats["by_category"] || []).index_by { |c| c["category"] }
+      total_all = (@stats["by_category"] || []).sum { |c| c["count"] }
+    %>
+
+    <!-- カテゴリ絞り込みタブ -->
+    <div class="flex flex-wrap gap-2">
+      <%= link_to "全体", admin_view_logs_path,
+            class: "px-3 py-1 rounded-full text-sm font-medium #{@category.nil? ? 'bg-primary text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+      <% %w[room_status ranking stats].each do |c| %>
+        <%= link_to "#{category_meta[c][:emoji]} #{category_meta[c][:label]}", admin_view_logs_path(category: c),
+              class: "px-3 py-1 rounded-full text-sm font-medium #{@category == c ? 'bg-primary text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
+      <% end %>
+    </div>
+
+    <!-- カテゴリ別サマリー（常に全体） -->
     <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
       <div class="card p-4">
-        <p class="text-xs text-gray-500">累計閲覧数</p>
-        <p class="text-2xl font-bold text-gray-900"><%= number_with_delimiter(@stats["total"]) %></p>
+        <p class="text-xs text-gray-500">累計（全カテゴリ）</p>
+        <p class="text-2xl font-bold text-gray-900"><%= number_with_delimiter(total_all) %></p>
       </div>
-      <% (@stats["by_source"] || []).each do |s| %>
-        <div class="card p-4">
-          <p class="text-xs text-gray-500"><%= s["source"] == "web" ? "Web" : (s["source"] == "discord" ? "Discord" : s["source"]) %></p>
-          <p class="text-2xl font-bold text-gray-900"><%= number_with_delimiter(s["count"]) %></p>
+      <% %w[room_status ranking stats].each do |c| %>
+        <div class="card p-4 <%= "ring-2 ring-primary" if @category == c %>">
+          <p class="text-xs text-gray-500"><%= category_meta[c][:emoji] %> <%= category_meta[c][:label] %></p>
+          <p class="text-2xl font-bold text-gray-900"><%= number_with_delimiter(by_category[c]&.fetch("count", 0) || 0) %></p>
         </div>
+      <% end %>
+    </div>
+
+    <!-- 経路別（現在の絞り込み反映） -->
+    <div class="flex flex-wrap gap-3">
+      <% (@stats["by_source"] || []).each do |s| %>
+        <div class="card px-4 py-2 flex items-center gap-2">
+          <span class="text-xs text-gray-500"><%= s["source"] == "web" ? "Web" : (s["source"] == "discord" ? "Discord" : s["source"]) %></span>
+          <span class="text-lg font-bold text-gray-900"><%= number_with_delimiter(s["count"]) %></span>
+        </div>
+      <% end %>
+      <% if @category %>
+        <span class="text-sm text-gray-500 self-center">（絞り込み: <%= category_meta[@category][:emoji] %> <%= category_meta[@category][:label] %>）</span>
       <% end %>
     </div>
 
     <!-- 日別 -->
     <div class="card p-4">
-      <h3 class="font-semibold text-gray-800 mb-3">日別閲覧数（直近<%= @days %>日）</h3>
+      <h3 class="font-semibold text-gray-800 mb-3">日別閲覧数（直近<%= @days %>日<%= "・#{category_meta[@category][:label]}" if @category %>）</h3>
       <% by_day = @stats["by_day"] || [] %>
       <% if by_day.any? %>
         <% max = by_day.map { |d| d["count"] }.max.to_f %>
@@ -56,6 +89,7 @@
             <thead class="bg-gray-100 border-b border-gray-200">
               <tr>
                 <th class="px-6 py-3 text-left font-semibold text-gray-700">ユーザー</th>
+                <th class="px-6 py-3 text-left font-semibold text-gray-700">カテゴリ</th>
                 <th class="px-6 py-3 text-left font-semibold text-gray-700">経路</th>
                 <th class="px-6 py-3 text-left font-semibold text-gray-700">日時</th>
               </tr>
@@ -70,6 +104,14 @@
                     <% else %>
                       <p class="text-gray-500"><%= row[:raw_identity] %></p>
                       <p class="text-xs text-gray-400">未解決のユーザー</p>
+                    <% end %>
+                  </td>
+                  <td class="px-6 py-3">
+                    <% meta = category_meta[row[:category]] %>
+                    <% if meta %>
+                      <span class="inline-block px-2 py-0.5 rounded text-xs <%= meta[:badge] %>"><%= meta[:emoji] %> <%= meta[:label] %></span>
+                    <% else %>
+                      <span class="inline-block px-2 py-0.5 rounded text-xs bg-gray-100 text-gray-600"><%= row[:category] %></span>
                     <% end %>
                   </td>
                   <td class="px-6 py-3">

--- a/discord-bot/src/commands/me.ts
+++ b/discord-bot/src/commands/me.ts
@@ -1,6 +1,7 @@
 import { createApi } from '../api.js';
 import type { Interaction, CommandEnv } from './types.js';
 import { getIntegerOption, getUserId, reply, replyEmbed } from './utils.js';
+import { logDiscordView } from '../viewLog.js';
 
 function formatDuration(totalSeconds: number): string {
     const hours = Math.floor(totalSeconds / 3600);
@@ -17,7 +18,7 @@ export const meCommand = {
         description: '自分の部室利用統計を表示します',
     },
 
-    async execute(interaction: Interaction, env: CommandEnv): Promise<object> {
+    async execute(interaction: Interaction, env: CommandEnv, ctx?: ExecutionContext): Promise<object> {
         const discordUserId = getUserId(interaction);
         if (!discordUserId) {
             return reply('ユーザー情報を取得できませんでした。');
@@ -30,9 +31,14 @@ export const meCommand = {
             const api = createApi(env);
             const data = await api.fetchMyStats(discordUserId, room);
 
-            // 統計機能が無効（工事中）
+            // 統計機能が無効（工事中）: 記録しない
             if (data.enabled === false) {
                 return reply(data.message ?? '🚧 現在工事中です');
+            }
+
+            // 閲覧ログ（統計）。応答をブロックせず記録する
+            if (ctx) {
+                ctx.waitUntil(logDiscordView(env, discordUserId, 'stats'));
             }
 
             const roomLabel = room === 'all' ? '全体' : `🚪第${room}部室`;

--- a/discord-bot/src/commands/rank.ts
+++ b/discord-bot/src/commands/rank.ts
@@ -2,7 +2,8 @@ import { createApi } from '../api.js';
 import type { RankingEntry } from '../api.js';
 import { PERIOD_LABELS } from '../constants.js';
 import type { Interaction, CommandEnv } from './types.js';
-import { getStringOption, reply, replyEmbed } from './utils.js';
+import { getStringOption, getUserId, reply, replyEmbed } from './utils.js';
+import { logDiscordView } from '../viewLog.js';
 
 function formatDuration(totalSeconds: number): string {
     const hours = Math.floor(totalSeconds / 3600);
@@ -26,7 +27,7 @@ export const rankCommand = {
         description: '部室の訪問回数・滞在時間ランキングを表示します',
     },
 
-    async execute(interaction: Interaction, env: CommandEnv): Promise<object> {
+    async execute(interaction: Interaction, env: CommandEnv, ctx?: ExecutionContext): Promise<object> {
         const type = getStringOption(interaction, 'type') ?? 'visits';
         const period = getStringOption(interaction, 'period') ?? 'all';
         const room = getStringOption(interaction, 'room');
@@ -35,9 +36,15 @@ export const rankCommand = {
             const api = createApi(env);
             const data = await api.fetchRanking(type, period, room ?? 'all');
 
-            // 統計機能が無効（工事中）
+            // 統計機能が無効（工事中）: 記録しない
             if (data.enabled === false) {
                 return reply(data.message ?? '🚧 現在工事中です');
+            }
+
+            // 閲覧ログ（ランキング）。応答をブロックせず記録する
+            const discordUserId = getUserId(interaction);
+            if (discordUserId && ctx) {
+                ctx.waitUntil(logDiscordView(env, discordUserId, 'ranking'));
             }
 
             if (data.ranking.length === 0) {

--- a/discord-bot/src/commands/status.ts
+++ b/discord-bot/src/commands/status.ts
@@ -15,11 +15,8 @@ export const statusCommand = {
         // 閲覧ログ（誰がいつ /status を見たか）を応答をブロックせず記録する。
         // 5分窓の重複間引きは取り込み Worker 側で行う。
         const discordUserId = getUserId(interaction);
-        if (discordUserId) {
-            const logPromise = logDiscordView(env, discordUserId);
-            if (ctx) {
-                ctx.waitUntil(logPromise);
-            }
+        if (discordUserId && ctx) {
+            ctx.waitUntil(logDiscordView(env, discordUserId, 'room_status'));
         }
 
         try {

--- a/discord-bot/src/viewLog.ts
+++ b/discord-bot/src/viewLog.ts
@@ -10,12 +10,15 @@ export interface ViewLogEnv {
 	INGEST_SHARED_SECRET?: string;
 }
 
+// 閲覧対象のカテゴリ
+export type ViewCategory = 'room_status' | 'ranking' | 'stats';
+
 // Service Binding のルーティングに使う内部URL（ホストは任意・pathname のみ意味を持つ）
 const INGEST_URL = 'https://view-log-worker.internal/view-logs';
 
 // Discord 経路の閲覧を記録する。
 // 5分窓の重複間引き（throttle）は取り込み Worker 側で行われる。
-export async function logDiscordView(env: ViewLogEnv, discordUserId: string): Promise<void> {
+export async function logDiscordView(env: ViewLogEnv, discordUserId: string, category: ViewCategory): Promise<void> {
 	const service = env.VIEW_LOG;
 	const secret = env.INGEST_SHARED_SECRET;
 	if (!service || !secret) return; // 未設定なら no-op
@@ -29,6 +32,7 @@ export async function logDiscordView(env: ViewLogEnv, discordUserId: string): Pr
 			},
 			body: JSON.stringify({
 				source: 'discord',
+				category,
 				discord_id: discordUserId,
 				viewed_at: new Date().toISOString(),
 			}),

--- a/view-log-worker/README.md
+++ b/view-log-worker/README.md
@@ -1,9 +1,9 @@
 # view-log-worker
 
-部室状況の「閲覧ログ」を取り込む Cloudflare Worker。
+「閲覧ログ」を取り込む Cloudflare Worker。カテゴリ（部室状況 `room_status` / ランキング `ranking` / 自分の統計 `stats`）ごとに、誰がいつ見たかを記録する。
 
 - **D1 (`VIEW_LOGS_DB`)** … 閲覧ログ本体（永続・分析対象）。Neon の容量・稼働を消費しない。
-- **KV (`THROTTLE_KV`)** … throttle 窓（同一ユーザーの5分以内の重複を間引く。TTL で自動失効）。
+- **KV (`THROTTLE_KV`)** … throttle 窓（同一ユーザー・同一カテゴリの5分以内の重複を間引く。TTL で自動失効）。
 
 Web(Rails) と Discord(bot) の両経路が、この Worker の `POST /view-logs` に集約して書き込む。
 

--- a/view-log-worker/README.md
+++ b/view-log-worker/README.md
@@ -15,10 +15,12 @@ Web(Rails) と Discord(bot) の両経路が、この Worker の `POST /view-logs
 ボディ（JSON）:
 ```jsonc
 // web 経路
-{ "source": "web", "user_id": 123, "viewed_at": "2026-08-24T01:23:45Z" }
+{ "source": "web", "category": "ranking", "user_id": 123, "viewed_at": "2026-08-24T01:23:45Z" }
 // discord 経路
-{ "source": "discord", "discord_id": "1122334455", "viewed_at": "2026-08-24T01:23:45Z" }
+{ "source": "discord", "category": "stats", "discord_id": "1122334455", "viewed_at": "2026-08-24T01:23:45Z" }
 ```
+- `category` … `room_status`（部室状況） / `ranking`（ランキング） / `stats`（自分の統計）。省略時は `room_status`。
+  throttle(5分)は **カテゴリ別** に効く。
 
 レスポンス:
 - `201 { "recorded": true }` … D1 に追記した
@@ -31,14 +33,17 @@ Web(Rails) と Discord(bot) の両経路が、この Worker の `POST /view-logs
 クエリパラメータ:
 - `days` … 日別集計の対象日数。範囲 `1〜365`、既定 `30`（範囲外・未指定・空は既定）
 - `limit` … 最近の閲覧の取得件数。範囲 `1〜500`、既定 `50`
+- `category` … `room_status` / `ranking` / `stats` で絞り込み（未指定は全体）。
+  絞り込み時も `by_category` は常に全体を返す（管理画面のカテゴリ切替用）。
 
 レスポンス `200`:
 ```jsonc
 {
   "total": 1234,
-  "by_source": [{ "source": "web", "count": 1000 }, { "source": "discord", "count": 234 }],
-  "by_day":    [{ "day": "2026-08-24", "count": 42 }],   // viewed_at 基準・降順
-  "recent":    [{ "id": 9, "user_id": 123, "discord_id": null, "source": "web", "viewed_at": "2026-08-24T01:23:45.000Z" }]
+  "by_source":   [{ "source": "web", "count": 1000 }, { "source": "discord", "count": 234 }],
+  "by_category": [{ "category": "room_status", "count": 900 }, { "category": "ranking", "count": 234 }, { "category": "stats", "count": 100 }],
+  "by_day":      [{ "day": "2026-08-24", "count": 42 }],   // viewed_at 基準・降順
+  "recent":      [{ "id": 9, "user_id": 123, "discord_id": null, "source": "web", "category": "ranking", "viewed_at": "2026-08-24T01:23:45.000Z" }]
 }
 ```
 - `401 / 500` … 認可失敗 / 集計失敗

--- a/view-log-worker/migrations/0002_add_category_to_view_logs.sql
+++ b/view-log-worker/migrations/0002_add_category_to_view_logs.sql
@@ -1,0 +1,5 @@
+-- 閲覧対象のカテゴリを追加（既存行はすべて部室状況として扱う）
+-- 値: 'room_status'（部室状況） | 'ranking'（ランキング） | 'stats'（自分の統計）
+ALTER TABLE view_logs ADD COLUMN category TEXT NOT NULL DEFAULT 'room_status';
+
+CREATE INDEX IF NOT EXISTS idx_view_logs_category_viewed ON view_logs (category, viewed_at);

--- a/view-log-worker/src/index.ts
+++ b/view-log-worker/src/index.ts
@@ -73,8 +73,12 @@ export default {
       }
       const days = clampInt(url.searchParams.get("days"), 30, 1, 365);
       const recentLimit = clampInt(url.searchParams.get("limit"), 50, 1, 500);
+      const categoryParam = url.searchParams.get("category");
+      const category = ["room_status", "ranking", "stats"].includes(categoryParam ?? "")
+        ? categoryParam!
+        : undefined;
       try {
-        const stats = await getStats(env, { days, recentLimit });
+        const stats = await getStats(env, { days, recentLimit, category });
         return json(200, stats);
       } catch (error) {
         console.error("getStats failed:", error);

--- a/view-log-worker/src/insert.ts
+++ b/view-log-worker/src/insert.ts
@@ -3,9 +3,9 @@ import type { Env, ViewLogEvent } from "./types.js";
 // 閲覧ログを D1 に1行追記する。
 export async function insertViewLog(env: Env, event: ViewLogEvent): Promise<void> {
   await env.VIEW_LOGS_DB.prepare(
-    `INSERT INTO view_logs (user_id, discord_id, source, viewed_at)
-     VALUES (?, ?, ?, ?)`
+    `INSERT INTO view_logs (user_id, discord_id, source, category, viewed_at)
+     VALUES (?, ?, ?, ?, ?)`
   )
-    .bind(event.user_id, event.discord_id, event.source, event.viewed_at)
+    .bind(event.user_id, event.discord_id, event.source, event.category, event.viewed_at)
     .run();
 }

--- a/view-log-worker/src/schema.ts
+++ b/view-log-worker/src/schema.ts
@@ -1,10 +1,11 @@
-import type { ViewLogEvent, ViewSource } from "./types.js";
+import type { ViewLogEvent, ViewSource, ViewCategory } from "./types.js";
 
 export type ParseResult =
   | { ok: true; event: ViewLogEvent }
   | { ok: false; error: string };
 
 const VALID_SOURCES: ViewSource[] = ["web", "discord"];
+const VALID_CATEGORIES: ViewCategory[] = ["room_status", "ranking", "stats"];
 
 // 受信 JSON を検証して ViewLogEvent に正規化する。
 export function parseViewLogEvent(body: unknown): ParseResult {
@@ -21,6 +22,15 @@ export function parseViewLogEvent(body: unknown): ParseResult {
   const viewedAt = raw.viewed_at;
   if (typeof viewedAt !== "string" || Number.isNaN(Date.parse(viewedAt))) {
     return { ok: false, error: "viewed_at must be a valid ISO8601 string" };
+  }
+
+  // category: 未指定は後方互換で "room_status"
+  let category: ViewCategory = "room_status";
+  if (raw.category !== undefined && raw.category !== null) {
+    if (typeof raw.category !== "string" || !VALID_CATEGORIES.includes(raw.category as ViewCategory)) {
+      return { ok: false, error: "category must be one of room_status, ranking, stats" };
+    }
+    category = raw.category as ViewCategory;
   }
 
   // user_id: 数値 or 数値文字列 or 未指定
@@ -59,6 +69,7 @@ export function parseViewLogEvent(body: unknown): ParseResult {
     ok: true,
     event: {
       source: source as ViewSource,
+      category,
       viewed_at: new Date(viewedAt).toISOString(), // UTC 正規化
       user_id: userId,
       discord_id: discordId,

--- a/view-log-worker/src/stats.ts
+++ b/view-log-worker/src/stats.ts
@@ -3,12 +3,14 @@ import type { Env } from "./types.js";
 export interface StatsResponse {
   total: number;
   by_source: { source: string; count: number }[];
+  by_category: { category: string; count: number }[];
   by_day: { day: string; count: number }[];
   recent: {
     id: number;
     user_id: number | null;
     discord_id: string | null;
     source: string;
+    category: string;
     viewed_at: string;
   }[];
 }
@@ -18,47 +20,63 @@ function sinceIso(days: number): string {
 }
 
 // 閲覧ログの集計を返す（Rails 管理画面 / 開発者確認用）。
-// Rails 側で user_id / discord_id を display_name に解決して表示する。
+// category を渡すとそのカテゴリに絞って集計する（by_category は常に全体を返し、
+// 管理画面でカテゴリを切り替えられるようにする）。
 export async function getStats(
   env: Env,
-  opts: { days: number; recentLimit: number }
+  opts: { days: number; recentLimit: number; category?: string }
 ): Promise<StatsResponse> {
   const db = env.VIEW_LOGS_DB;
+  const cat = opts.category;
+  // category 絞り込み用の WHERE 句とバインド値
+  const catWhere = cat ? "category = ?" : "";
+  const catBind = cat ? [cat] : [];
 
   const totalRow = await db
-    .prepare("SELECT COUNT(*) AS c FROM view_logs")
+    .prepare(`SELECT COUNT(*) AS c FROM view_logs${cat ? " WHERE category = ?" : ""}`)
+    .bind(...catBind)
     .first<{ c: number }>();
 
   const bySource = await db
     .prepare(
-      "SELECT source, COUNT(*) AS count FROM view_logs GROUP BY source ORDER BY count DESC"
+      `SELECT source, COUNT(*) AS count FROM view_logs${cat ? " WHERE category = ?" : ""}
+       GROUP BY source ORDER BY count DESC`
     )
+    .bind(...catBind)
     .all<{ source: string; count: number }>();
+
+  // カテゴリ別は常に全体（絞り込みなし）で集計＝サマリーカードで全カテゴリを提示
+  const byCategory = await db
+    .prepare(
+      "SELECT category, COUNT(*) AS count FROM view_logs GROUP BY category ORDER BY count DESC"
+    )
+    .all<{ category: string; count: number }>();
 
   const byDay = await db
     .prepare(
       `SELECT substr(viewed_at, 1, 10) AS day, COUNT(*) AS count
        FROM view_logs
-       WHERE viewed_at >= ?
+       WHERE viewed_at >= ?${catWhere ? ` AND ${catWhere}` : ""}
        GROUP BY day
        ORDER BY day DESC`
     )
-    .bind(sinceIso(opts.days))
+    .bind(sinceIso(opts.days), ...catBind)
     .all<{ day: string; count: number }>();
 
   const recent = await db
     .prepare(
-      `SELECT id, user_id, discord_id, source, viewed_at
-       FROM view_logs
+      `SELECT id, user_id, discord_id, source, category, viewed_at
+       FROM view_logs${cat ? " WHERE category = ?" : ""}
        ORDER BY viewed_at DESC, id DESC
        LIMIT ?`
     )
-    .bind(opts.recentLimit)
+    .bind(...catBind, opts.recentLimit)
     .all<StatsResponse["recent"][number]>();
 
   return {
     total: totalRow?.c ?? 0,
     by_source: bySource.results ?? [],
+    by_category: byCategory.results ?? [],
     by_day: byDay.results ?? [],
     recent: recent.results ?? [],
   };

--- a/view-log-worker/src/throttle.ts
+++ b/view-log-worker/src/throttle.ts
@@ -1,11 +1,11 @@
 import type { Env, ViewLogEvent } from "./types.js";
 import { DEFAULT_THROTTLE_TTL_SECONDS } from "./types.js";
 
-// throttle キー: 経路 + 識別子 単位。
-// web は user_id、discord は discord_id で区別する。
+// throttle キー: カテゴリ + 経路 + 識別子 単位。
+// カテゴリを含めるので、同一ユーザーが5分内にランキングと統計を見た場合は別々に記録される。
 export function throttleKey(event: ViewLogEvent): string {
   const identity = event.source === "web" ? `u:${event.user_id}` : `d:${event.discord_id}`;
-  return `throttle:${event.source}:${identity}`;
+  return `throttle:${event.category}:${event.source}:${identity}`;
 }
 
 export function throttleTtlSeconds(env: Env): number {

--- a/view-log-worker/src/types.ts
+++ b/view-log-worker/src/types.ts
@@ -13,9 +13,13 @@ export interface Env {
 
 export type ViewSource = "web" | "discord";
 
+// 閲覧対象のカテゴリ
+export type ViewCategory = "room_status" | "ranking" | "stats";
+
 // 取り込みエンドポイントが受け取る閲覧イベント
 export interface ViewLogEvent {
   source: ViewSource;
+  category: ViewCategory;
   viewed_at: string; // UTC ISO8601
   user_id: number | null; // Rails users.id（web）
   discord_id: string | null; // Discord ユーザーID（discord）

--- a/view-log-worker/test/logic.test.ts
+++ b/view-log-worker/test/logic.test.ts
@@ -12,7 +12,19 @@ describe("parseViewLogEvent", () => {
       expect(r.event.user_id).toBe(12);
       expect(r.event.discord_id).toBeNull();
       expect(r.event.viewed_at).toBe("2026-08-24T01:00:00.000Z");
+      expect(r.event.category).toBe("room_status"); // 未指定は後方互換で room_status
     }
+  });
+
+  it("accepts an explicit category", () => {
+    const r = parseViewLogEvent({ source: "web", user_id: 1, category: "ranking", viewed_at: "2026-08-24T01:00:00Z" });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.event.category).toBe("ranking");
+  });
+
+  it("rejects unknown category", () => {
+    const r = parseViewLogEvent({ source: "web", user_id: 1, category: "nope", viewed_at: "2026-08-24T01:00:00Z" });
+    expect(r.ok).toBe(false);
   });
 
   it("accepts a valid discord event", () => {
@@ -57,14 +69,20 @@ describe("parseViewLogEvent", () => {
 });
 
 describe("throttleKey", () => {
-  it("keys web by user_id", () => {
-    expect(throttleKey({ source: "web", user_id: 5, discord_id: null, viewed_at: "x" })).toBe(
-      "throttle:web:u:5"
-    );
+  it("keys web by category + user_id", () => {
+    expect(
+      throttleKey({ source: "web", category: "room_status", user_id: 5, discord_id: null, viewed_at: "x" })
+    ).toBe("throttle:room_status:web:u:5");
   });
-  it("keys discord by discord_id", () => {
-    expect(throttleKey({ source: "discord", user_id: null, discord_id: "42", viewed_at: "x" })).toBe(
-      "throttle:discord:d:42"
+  it("keys discord by category + discord_id", () => {
+    expect(
+      throttleKey({ source: "discord", category: "ranking", user_id: null, discord_id: "42", viewed_at: "x" })
+    ).toBe("throttle:ranking:discord:d:42");
+  });
+  it("separates categories for the same user", () => {
+    const base = { source: "web" as const, user_id: 5, discord_id: null, viewed_at: "x" };
+    expect(throttleKey({ ...base, category: "ranking" })).not.toBe(
+      throttleKey({ ...base, category: "stats" })
     );
   });
 });


### PR DESCRIPTION
## 概要
部室状況と同じ仕組みで、**ランキング**（`/stats/ranking`・Discord `/rank`）と **自分の統計**（`/stats/me`・Discord `/me`）の閲覧数ログも取得する。閲覧ログに **`category`**（`room_status`/`ranking`/`stats`）を追加してカテゴリで分離する。

（#354 統計トグルはマージ済み。本PRは「工事中時は記録しない」ためにその enabled 判定を利用する。）

## 実装
### view-log-worker
- `view_logs` に `category TEXT NOT NULL DEFAULT 'room_status'` 追加（migration `0002`、既存行は自動的に room_status）
- 検証(`schema.ts`)・挿入(`insert.ts`)・throttleキー(`throttle.ts`)に category → **throttle はカテゴリ別**
- `stats.ts`: `by_category` と `?category=` 絞り込み（`by_category` は常に全体＝管理画面の切替用）

### Rails
- `RoomViewLogger.log_web_view(user, category:)` / `RoomViewLogJob` に category
- フック: `stats#ranking`→`ranking` / `stats#me`→`stats` / `room_statuses#index`→`room_status`（工事中時は before_action で弾かれ記録されない）

### Discord bot（Service Binding 経由・/status と同方式）
- `rank.ts`/`me.ts`: `enabled` 確認後（実際に表示する時のみ）に `ranking`/`stats` を記録

### 管理画面 /admin/view_logs
- カテゴリ別サマリーカード＋絞り込みタブ（全体/部室状況/ランキング/統計）＋一覧にカテゴリバッジ

## 検証（実機）
- Worker: typecheck / 19テスト / dry-run。ライブで category 記録・不正カテゴリ422・by_category・カテゴリ絞り込みを確認
- Rails: boot・ERBコンパイル・`RoomViewLogJob(category:"ranking")` → worker に `('web','ranking',1)` 記録を確認
- テストデータ削除済み・本番D1は実データ(room_status)のみ

## デプロイ時の注意
- **D1 migration 0002 適用が必要**（既に本番D1へ適用済み・追加のみ・既定 room_status で挙動不変）
- **Discord bot の再デプロイが必要**（rank/me の記録反映）。develop マージ後の CI で反映。

https://claude.ai/code/session_01E3J8cVRy4imtmyiDTrTazk

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * 閲覧ログを「部室状況」「ランキング」「統計」カテゴリ別に記録・表示できるようになりました。
  * 管理画面でカテゴリ別の絞り込み、集計、最近のログ確認が可能になりました。
  * ランキングや統計の閲覧ログも自動記録されます。
  * 統計情報でカテゴリ別集計とカテゴリ指定の絞り込みに対応しました。

* **改善**
  * 未指定または不正なカテゴリは適切に処理され、カテゴリごとに閲覧ログの制限を管理します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->