### PR TITLE
feat: アプリ全体のアクセス数を閲覧ログに追加（category: app）

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,6 +5,11 @@ DB_PASSWORD=
 DB_TEST_NAME=
 DB_USERNAME=
 
+# 注意: DATABASE_URL を設定すると全環境（test を含む）で database.yml より優先される。
+# 本番・開発用の DATABASE_URL を .env に書く場合は、テストが本番DBを参照しないよう
+# .env.test でローカルのテスト用 DATABASE_URL を必ず上書きすること。
+# DATABASE_URL=
+
 # OAuth2 / Authentication
 CLIENT_ID=
 CLIENT_SECRET=

--- a/.github/workflows/deploy-view-log-worker.yml
+++ b/.github/workflows/deploy-view-log-worker.yml
@@ -6,16 +6,28 @@ on:
     paths:
       - 'view-log-worker/**'
 
+# デプロイ先（jyogi-view-log-worker）単位のグループ。
+# develop/main の両方から同じ Worker にデプロイされるため、ブランチを跨いで直列化し、
+# 新しいコミットの実行を優先する（古い実行が後からデプロイを完了するのを防ぐ）。
+concurrency:
+  group: deploy-view-log-worker
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/deploy-view-log-worker.yml
+++ b/.github/workflows/deploy-view-log-worker.yml
@@ -1,0 +1,41 @@
+name: Deploy View Log Worker to Cloudflare Workers
+
+on:
+  push:
+    branches: [develop,main]
+    paths:
+      - 'view-log-worker/**'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: view-log-worker/package-lock.json
+
+      - name: Install dependencies
+        working-directory: view-log-worker
+        run: npm ci
+
+      - name: Typecheck
+        working-directory: view-log-worker
+        run: npm run typecheck
+
+      - name: Test
+        working-directory: view-log-worker
+        run: npm test
+
+      - name: Deploy to Cloudflare Workers
+        working-directory: view-log-worker
+        run: npx wrangler deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}

--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,9 @@
 # Ignore node_modules
 /node_modules
 
+# wrangler ローカル用シークレット（view-log-worker ローカル検証で使用）
+view-log-worker/.dev.vars
+
 # 個人設定ファイル
 CLAUDE.md
 .claude/

--- a/app/controllers/admin/view_logs_controller.rb
+++ b/app/controllers/admin/view_logs_controller.rb
@@ -1,7 +1,7 @@
 class Admin::ViewLogsController < Admin::BaseController
   DAYS = 30
   RECENT_LIMIT = 100
-  CATEGORIES = %w[room_status ranking stats].freeze
+  CATEGORIES = %w[room_status ranking stats app].freeze
 
   def index
     @category = params[:category].presence_in(CATEGORIES)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,11 @@ class ApplicationController < ActionController::Base
 
   include JyogiAuthenticatable
 
+  # アプリ全体へのアクセス記録（category: "app"）。
+  # 未ログイン（authenticate_user! のリダイレクト後もコールバックは継続する）は
+  # log_app_access 内のガードで弾く。
+  before_action :log_app_access
+
   # ビューでもcurrent_userを使えるようにする
   helper_method :current_user, :user_signed_in?, :effective_admin?, :effective_admin_or_manager?
 
@@ -14,5 +19,29 @@ class ApplicationController < ActionController::Base
 
   def effective_admin_or_manager?
     current_user&.manager? || effective_admin?
+  end
+
+  private
+
+  # メンバー画面（HTML GET）へのアクセスを「アプリ全体へのアクセス」として記録する。
+  # - 画面種別は問わない（ダッシュボード・予約・鍵・部室状況など全画面が対象）
+  # - API / 管理画面 / 認証 / ヘルスチェックは対象外
+  # - 5分以内の再アクセスは RoomViewLogger / Worker 側の throttle で間引かれる
+  #   （＝「利用セッション数」的な指標になる）
+  APP_ACCESS_EXCLUDED_PREFIXES = %w[/api /admin /auth /up].freeze
+
+  def log_app_access
+    return unless request.get? && request.format.html?
+    return if current_user.blank?
+    return if app_access_excluded_path?
+
+    RoomViewLogger.log_web_view(current_user, category: "app")
+  end
+
+  def app_access_excluded_path?
+    path = request.path
+    APP_ACCESS_EXCLUDED_PREFIXES.any? do |prefix|
+      path == prefix || path.start_with?("#{prefix}/")
+    end
   end
 end

--- a/app/services/room_view_logger.rb
+++ b/app/services/room_view_logger.rb
@@ -1,18 +1,19 @@
 # frozen_string_literal: true
 
-# 部室状況の閲覧ログ記録の入口（Web 経路）。
+# 閲覧ログ記録の入口（Web 経路）。
 # - 実際の保存は RoomViewLogJob 経由で view-log-worker(Cloudflare) が担う。
 # - ここでの throttle は「無駄なジョブ投入を抑える一次判定」であり、
 #   経路横断（Web/Discord）の最終的な5分重複判定は Worker 側 KV が権威。
 #   ※本アプリの本番キャッシュがプロセスローカルでも、Worker 側で必ず間引かれる。
 class RoomViewLogger
   THROTTLE_WINDOW = 5.minutes
-  VALID_CATEGORIES = %w[room_status ranking stats].freeze
+  # app: アプリ全体へのアクセス（画面種別を問わない。5分窓でセッション的に数える）
+  VALID_CATEGORIES = %w[room_status ranking stats app].freeze
 
   # ログイン中ユーザーの Web 閲覧を記録する。
   # メイン処理をブロック・失敗させないよう、例外は握りつぶしてログのみ。
   # @param user [User, nil]
-  # @param category [String] "room_status" / "ranking" / "stats"
+  # @param category [String] "room_status" / "ranking" / "stats" / "app"
   def self.log_web_view(user, category: "room_status")
     return if user.blank?
     return unless enabled?

--- a/app/views/admin/view_logs/index.html.erb
+++ b/app/views/admin/view_logs/index.html.erb
@@ -15,8 +15,10 @@
       category_meta = {
         "room_status" => { label: "部室状況", emoji: "🚪", badge: "bg-emerald-100 text-emerald-700" },
         "ranking"     => { label: "ランキング", emoji: "👑", badge: "bg-amber-100 text-amber-700" },
-        "stats"       => { label: "統計", emoji: "📊", badge: "bg-sky-100 text-sky-700" }
+        "stats"       => { label: "統計", emoji: "📊", badge: "bg-sky-100 text-sky-700" },
+        "app"         => { label: "アプリ", emoji: "📱", badge: "bg-violet-100 text-violet-700" }
       }
+      categories = Admin::ViewLogsController::CATEGORIES
       by_category = (@stats["by_category"] || []).index_by { |c| c["category"] }
       total_all = (@stats["by_category"] || []).sum { |c| c["count"] }
     %>
@@ -25,19 +27,19 @@
     <div class="flex flex-wrap gap-2">
       <%= link_to "全体", admin_view_logs_path,
             class: "px-3 py-1 rounded-full text-sm font-medium #{@category.nil? ? 'bg-primary text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
-      <% %w[room_status ranking stats].each do |c| %>
+      <% categories.each do |c| %>
         <%= link_to "#{category_meta[c][:emoji]} #{category_meta[c][:label]}", admin_view_logs_path(category: c),
               class: "px-3 py-1 rounded-full text-sm font-medium #{@category == c ? 'bg-primary text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'}" %>
       <% end %>
     </div>
 
     <!-- カテゴリ別サマリー（常に全体） -->
-    <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+    <div class="grid grid-cols-2 md:grid-cols-5 gap-3">
       <div class="card p-4">
         <p class="text-xs text-gray-500">累計（全カテゴリ）</p>
         <p class="text-2xl font-bold text-gray-900"><%= number_with_delimiter(total_all) %></p>
       </div>
-      <% %w[room_status ranking stats].each do |c| %>
+      <% categories.each do |c| %>
         <div class="card p-4 <%= "ring-2 ring-primary" if @category == c %>">
           <p class="text-xs text-gray-500"><%= category_meta[c][:emoji] %> <%= category_meta[c][:label] %></p>
           <p class="text-2xl font-bold text-gray-900"><%= number_with_delimiter(by_category[c]&.fetch("count", 0) || 0) %></p>

--- a/test/controllers/app_access_logging_test.rb
+++ b/test/controllers/app_access_logging_test.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# ApplicationController のアプリ全体アクセス記録（category: "app"）のテスト
+class AppAccessLoggingTest < ActionDispatch::IntegrationTest
+  # RoomViewLogger.log_web_view を一時的に差し替えて呼び出しを記録する
+  def capture_app_view_logs
+    logged = []
+    original = RoomViewLogger.method(:log_web_view)
+    RoomViewLogger.define_singleton_method(:log_web_view) do |user, category: "room_status"|
+      logged << [ user&.id, category ]
+    end
+    yield
+    logged
+  ensure
+    RoomViewLogger.define_singleton_method(:log_web_view, original)
+  end
+
+  test "ログイン中のメンバー画面GETは category=app で記録される" do
+    logged = capture_app_view_logs do
+      sign_in_as(users(:one))
+      get "/reservations"
+    end
+
+    assert_equal [ [ users(:one).id, "app" ] ], logged
+  end
+
+  test "未ログインのアクセスは記録されない" do
+    logged = capture_app_view_logs do
+      get "/reservations"
+    end
+
+    assert_empty logged
+  end
+
+  test "APIパスは記録されない" do
+    logged = capture_app_view_logs do
+      sign_in_as(users(:one))
+      get "/api/users/me"
+    end
+
+    assert_empty logged
+  end
+
+  test "POSTリクエストは記録されない" do
+    logged = capture_app_view_logs do
+      sign_in_as(users(:one))
+      post "/room_statuses/1/exit_room"
+    end
+
+    assert_empty logged
+  end
+end

--- a/view-log-worker/README.md
+++ b/view-log-worker/README.md
@@ -1,6 +1,6 @@
 # view-log-worker
 
-「閲覧ログ」を取り込む Cloudflare Worker。カテゴリ（部室状況 `room_status` / ランキング `ranking` / 自分の統計 `stats`）ごとに、誰がいつ見たかを記録する。
+「閲覧ログ」を取り込む Cloudflare Worker。カテゴリ（部室状況 `room_status` / ランキング `ranking` / 自分の統計 `stats` / アプリ全体アクセス `app`）ごとに、誰がいつ見たかを記録する。
 
 - **D1 (`VIEW_LOGS_DB`)** … 閲覧ログ本体（永続・分析対象）。Neon の容量・稼働を消費しない。
 - **KV (`THROTTLE_KV`)** … throttle 窓（同一ユーザー・同一カテゴリの5分以内の重複を間引く。TTL で自動失効）。
@@ -19,7 +19,7 @@ Web(Rails) と Discord(bot) の両経路が、この Worker の `POST /view-logs
 // discord 経路
 { "source": "discord", "category": "stats", "discord_id": "1122334455", "viewed_at": "2026-08-24T01:23:45Z" }
 ```
-- `category` … `room_status`（部室状況） / `ranking`（ランキング） / `stats`（自分の統計）。省略時は `room_status`。
+- `category` … `room_status`（部室状況） / `ranking`（ランキング） / `stats`（自分の統計） / `app`（アプリ全体アクセス・Rails から画面種別なしで送られる）。省略時は `room_status`。
   throttle(5分)は **カテゴリ別** に効く。
 
 レスポンス:
@@ -33,7 +33,7 @@ Web(Rails) と Discord(bot) の両経路が、この Worker の `POST /view-logs
 クエリパラメータ:
 - `days` … 日別集計の対象日数。範囲 `1〜365`、既定 `30`（範囲外・未指定・空は既定）
 - `limit` … 最近の閲覧の取得件数。範囲 `1〜500`、既定 `50`
-- `category` … `room_status` / `ranking` / `stats` で絞り込み（未指定は全体）。
+- `category` … `room_status` / `ranking` / `stats` / `app` で絞り込み（未指定は全体）。
   絞り込み時も `by_category` は常に全体を返す（管理画面のカテゴリ切替用）。
 
 レスポンス `200`:

--- a/view-log-worker/src/index.ts
+++ b/view-log-worker/src/index.ts
@@ -74,7 +74,7 @@ export default {
       const days = clampInt(url.searchParams.get("days"), 30, 1, 365);
       const recentLimit = clampInt(url.searchParams.get("limit"), 50, 1, 500);
       const categoryParam = url.searchParams.get("category");
-      const category = ["room_status", "ranking", "stats"].includes(categoryParam ?? "")
+      const category = ["room_status", "ranking", "stats", "app"].includes(categoryParam ?? "")
         ? categoryParam!
         : undefined;
       try {

--- a/view-log-worker/src/schema.ts
+++ b/view-log-worker/src/schema.ts
@@ -5,7 +5,7 @@ export type ParseResult =
   | { ok: false; error: string };
 
 const VALID_SOURCES: ViewSource[] = ["web", "discord"];
-const VALID_CATEGORIES: ViewCategory[] = ["room_status", "ranking", "stats"];
+const VALID_CATEGORIES: ViewCategory[] = ["room_status", "ranking", "stats", "app"];
 
 // 受信 JSON を検証して ViewLogEvent に正規化する。
 export function parseViewLogEvent(body: unknown): ParseResult {
@@ -28,7 +28,7 @@ export function parseViewLogEvent(body: unknown): ParseResult {
   let category: ViewCategory = "room_status";
   if (raw.category !== undefined && raw.category !== null) {
     if (typeof raw.category !== "string" || !VALID_CATEGORIES.includes(raw.category as ViewCategory)) {
-      return { ok: false, error: "category must be one of room_status, ranking, stats" };
+      return { ok: false, error: "category must be one of room_status, ranking, stats, app" };
     }
     category = raw.category as ViewCategory;
   }

--- a/view-log-worker/src/types.ts
+++ b/view-log-worker/src/types.ts
@@ -14,7 +14,8 @@ export interface Env {
 export type ViewSource = "web" | "discord";
 
 // 閲覧対象のカテゴリ
-export type ViewCategory = "room_status" | "ranking" | "stats";
+// app: アプリ全体へのアクセス（画面種別を問わない・5分窓でセッション的に数える）
+export type ViewCategory = "room_status" | "ranking" | "stats" | "app";
 
 // 取り込みエンドポイントが受け取る閲覧イベント
 export interface ViewLogEvent {

--- a/view-log-worker/test/logic.test.ts
+++ b/view-log-worker/test/logic.test.ts
@@ -22,6 +22,12 @@ describe("parseViewLogEvent", () => {
     if (r.ok) expect(r.event.category).toBe("ranking");
   });
 
+  it("accepts the app category (アプリ全体アクセス)", () => {
+    const r = parseViewLogEvent({ source: "web", user_id: 1, category: "app", viewed_at: "2026-08-24T01:00:00Z" });
+    expect(r.ok).toBe(true);
+    if (r.ok) expect(r.event.category).toBe("app");
+  });
+
   it("rejects unknown category", () => {
     const r = parseViewLogEvent({ source: "web", user_id: 1, category: "nope", viewed_at: "2026-08-24T01:00:00Z" });
     expect(r.ok).toBe(false);
@@ -83,6 +89,12 @@ describe("throttleKey", () => {
     const base = { source: "web" as const, user_id: 5, discord_id: null, viewed_at: "x" };
     expect(throttleKey({ ...base, category: "ranking" })).not.toBe(
       throttleKey({ ...base, category: "stats" })
+    );
+  });
+  it("separates app from room_status for the same user (画面ログと全体アクセスは独立)", () => {
+    const base = { source: "web" as const, user_id: 5, discord_id: null, viewed_at: "x" };
+    expect(throttleKey({ ...base, category: "app" })).not.toBe(
+      throttleKey({ ...base, category: "room_status" })
     );
   });
 });


### PR DESCRIPTION
## 概要

部室状況・ランキング・統計の画面別ログに加え、**アプリ全体でのアクセス回数**（新カテゴリ `app`）を記録できるようにする。

### 「1アクセス」の定義

- ログインユーザーがメンバー画面（`/api` `/admin` `/auth` `/up` 以外）を **HTML GET** したタイミングで記録
- 既存と同じ **5分throttle** で間引くため、5分以内の画面遷移では増えない（＝「利用セッション数」的な指標）
- 既存カテゴリとは throttle キーが分かれるので、部室状況を開いても `app` と `room_status` が独立して記録される
- Discord bot は従来どおり画面別カテゴリのみ（本PRでは変更なし）

## 変更点

### view-log-worker
- `category` に `"app"` を追加（`types.ts` / `schema.ts` / `index.ts` の許可リスト）
- **migration 不要**（`category` は TEXT 列で列挙制約なし・既存行への影響なし）
- stats エンドポイントの `category=app` 絞り込みに対応
- テスト: `app` の受理、`app` と `room_status` の throttle キー分離

### Rails
- `ApplicationController` に `before_action :log_app_access` を追加
  - GET + HTML + ログイン済み + 対象パスのみ（未ログインはガードで除外）
  - `RoomViewLogger` 経由で非同期送信（既存のベストエフォート方式）
- 管理画面 `/admin/view_logs` に「📱 アプリ」タブ・サマリーカードを追加
  - タブ/カードは `CATEGORIES` 定数から生成するよう変更（カテゴリ追加が1箇所で完結）
- 統合テスト `test/controllers/app_access_logging_test.rb`（メンバー画面GET記録 / 未ログイン・API・POST 除外）

### CI/CD
- **`deploy-view-log-worker.yml` を新規追加** — view-log-worker はこれまで手動デプロイのみで、どのワークフローにも含まれていなかった。`view-log-worker/**` 変更時に typecheck/test → wrangler deploy を自動実行（discord-bot workflow と同形式）
- マージすると本番 worker に `app` 対応が自動デプロイされる（Rails 側は raspi デプロイ、CI は rubocop/test が走る）

### その他
- `.env.example` に注意書き: `DATABASE_URL` は test 環境でも `database.yml` より優先されるため、`.env` に本番（Neon）の URL を書く場合は `.env.test` でローカル向け URL を上書きする必要がある（実際にローカルテストが本番DB参照しかけたため記録）
- `.gitignore` に `view-log-worker/.dev.vars`（wrangler dev 用ローカルシークレット）を追加

## 動作確認

- [x] worker: typecheck / 21 tests 通過
- [x] Rails: 75 runs, 137 assertions, 0 failures（rubocop・brakemanも通過）
- [x] ローカルE2E: `wrangler dev`（ローカルD1/KV）+ `.env.local` で取り込み先をローカルに切り替え、
  - アプリアクセス → 管理画面「📱 アプリ」のカウント上昇
  - 同一イベント再送 → `throttled` で間引き
  - stats API `category=app` の `by_category` / `by_day` / `recent` が正常
- [ ] マージ後: 本番 worker へ自動デプロイ → 本番で「📱 アプリ」のカウント上昇

## 備考

- マージ前の本番は旧 worker のため `app` カテゴリの取り込みが422で拒否される（Rails側は変更済み）。**マージによる自動デプロイで解消される**（テーブル定義変更がないため先行的な本番デプロイも不要）
- ローカル検証手順（README `.dev.vars` + `migrate:local` + `wrangler dev` + `.env.local`）はコミットメッセージに記載

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
  - ログイン済みユーザーのアプリ画面アクセスを、新しい「アプリ全体アクセス」カテゴリとして記録できるようになりました。
  - 管理画面の閲覧ログで、アプリ全体アクセスの集計表示とカテゴリ絞り込みに対応しました。
  - 閲覧ログの統計取得で「アプリ全体アクセス」を指定できるようになりました。

- **ドキュメント**
  - 閲覧ログカテゴリの説明に「アプリ全体アクセス」を追加しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->