### PR TITLE
fix(ci): view-log-worker デプロイの Node バージョンを 22 に上げる

### DIFF
--- a/.github/workflows/deploy-view-log-worker.yml
+++ b/.github/workflows/deploy-view-log-worker.yml
@@ -29,7 +29,9 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
-          node-version: '20'
+          # wrangler 4.78+ は Node 22 以降を要求する（lockfile は 4.125.0 に解決済み）。
+          # Node 20 のままデプロイすると "Wrangler requires at least Node.js v22.0.0" で失敗する。
+          node-version: '22'
           cache: 'npm'
           cache-dependency-path: view-log-worker/package-lock.json
 

--- a/.github/workflows/deploy-view-log-worker.yml
+++ b/.github/workflows/deploy-view-log-worker.yml
@@ -5,6 +5,9 @@ on:
     branches: [develop,main]
     paths:
       - 'view-log-worker/**'
+      # workflow 自体の変更（Node バージョン等のデプロイ環境修正）でも
+      # 再デプロイされるようにする
+      - '.github/workflows/deploy-view-log-worker.yml'
 
 # デプロイ先（jyogi-view-log-worker）単位のグループ。
 # develop/main の両方から同じ Worker にデプロイされるため、ブランチを跨いで直列化し、


### PR DESCRIPTION
## 概要

PR #356 マージ後の view-log-worker デプロイが失敗し、本番 worker が旧コードのまま `app` カテゴリ（アプリ全体アクセス）の取り込みを 422 で拒否し続けている状態のため、その修正。

## 原因

```
Wrangler requires at least Node.js v22.0.0. You are using v20.20.2.
```

- `deploy-view-log-worker.yml` は discord-bot workflow を流用して `node-version: '20'` で作成した
- view-log-worker の lockfile は wrangler **4.125.0** に解決されており Node 22+ が要件（discord-bot は wrangler 4.78.0 固定なので Node 20 で動く）
- 結果、デプロイ step だけが失敗（CI と raspi デプロイは成功）

## 修正

- `node-version: '20'` → `'22'`（LTS）
- 要件の根拠をコメントで明記

## 影響

- この PR をマージすると workflow が再実行され、本番 worker に `app` 対応がデプロイされる
- マージまでの間に本番 Rails が送った `app` イベントは旧 worker の 422（リトライ不可）で失われる。**過去分は復帰しない**が、マージ後は即座に記録が始まる

## 動作確認

- [x] YAML パース・`node-version: 22` の反映を機械確認
- [ ] マージ後: workflow 成功 → 本番 stats API の `by_category` に `app` が出現 → 管理画面「📱 アプリ」のカウント上昇

## 備考（スコープ外）

`deploy-discord-bot.yml` も同様に Node 20 だが、現状 wrangler 4.78.0 で動作しているため今回 untouched。lockfile 更新時に同一事故が起きうる点は別途対応を推奨。